### PR TITLE
Add cost calculation logic for salary drafts

### DIFF
--- a/app/controllers/rosters_controller.rb
+++ b/app/controllers/rosters_controller.rb
@@ -76,10 +76,11 @@ class RostersController < ScopedGameController
   end
 
   def set_page_variables
-    @players = @game.players
+    @players = @game.players.includes(:external_scores)
     @countries = @players.pluck(:country).uniq.sort
     @players = apply_filters(players: @players)
     @players = @players.page(params[:page]).per(25)
+    @players.each { |player| player.cost = @roster.draft.cost_for(player:) }
     @filters = filter_params
   end
 

--- a/app/controllers/salary_drafts_controller.rb
+++ b/app/controllers/salary_drafts_controller.rb
@@ -10,6 +10,8 @@ class SalaryDraftsController < ScopedGameController
 
   def show
     @salary_draft = SalaryDraft.find(params[:id])
+    return unless current_user
+
     @participation = current_user.participations.find_by(draft: @salary_draft)
   end
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,4 +1,11 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
-import "./controllers"
 import * as bootstrap from "bootstrap"
+
+window.bootstrap = bootstrap
+
+import "./controllers"
+
+import jquery from "jquery"
+window.jQuery = jquery
+window.$ = jquery

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,3 +9,6 @@ application.register("hello", HelloController)
 
 import RemovalsController from "./removals_controller"
 application.register("removals", RemovalsController)
+
+import TableFiltersController from "./table_filters_controller"
+application.register("table-filters", TableFiltersController)

--- a/app/javascript/controllers/table_filters_controller.js
+++ b/app/javascript/controllers/table_filters_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ['input', 'form']
+  connect() {
+    let form = $(this.formTarget)
+    let input = $(this.inputTarget)
+    input.on('input',
+        debounce(
+            function () {
+              form.find('input[type=submit]').click()
+            }, 500)
+    )
+  }
+}
+
+function debounce(func, delay) {
+    let timeoutId;
+    return function(...args) {
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(() => {
+            func.apply(this, args);
+        }, delay);
+    };
+}

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,5 +1,7 @@
 class Player < ApplicationRecord
 
+  attr_accessor :cost
+
   validates :name, presence: true
   validates :external_id, presence: true
   belongs_to :game
@@ -8,6 +10,14 @@ class Player < ApplicationRecord
 
   def current_score
     external_scores.order('created_at desc').first&.score
+  end
+
+  def latest_score_before(date:)
+    external_scores.order('created_at desc').where(created_at: ..date).first&.score
+  end
+
+  def decorated_cost
+    format('%0.02f', cost)
   end
 
   include ExternalResource

--- a/app/models/roster.rb
+++ b/app/models/roster.rb
@@ -10,6 +10,11 @@ class Roster < ApplicationRecord
   accepts_nested_attributes_for :roster_players, allow_destroy: true
 
   validate :roster_size
+  validate :roster_cost
+
+  def total_cost
+    roster_players.sum { |roster_player| roster_player.player_cost.to_f }.round(2)
+  end
 
   private
 
@@ -17,6 +22,12 @@ class Roster < ApplicationRecord
     return true unless draft && roster_players.length > draft.roster_size
 
     errors.add(:players, :roster_too_big)
+  end
+
+  def roster_cost
+    return true unless draft && total_cost > draft.price_cap
+
+    errors.add(:players, :total_cost_exceeded)
   end
 
 end

--- a/app/models/roster_player.rb
+++ b/app/models/roster_player.rb
@@ -2,5 +2,15 @@ class RosterPlayer < ApplicationRecord
 
   belongs_to :player
   belongs_to :roster
+  has_one :participation, through: :roster
+  has_one :draft, through: :participation
+
+  def player_cost
+    draft.cost_for(player:)
+  end
+
+  def decorated_player_cost
+    format('%0.02f', player_cost)
+  end
 
 end

--- a/app/models/salary_draft.rb
+++ b/app/models/salary_draft.rb
@@ -5,4 +5,8 @@ class SalaryDraft < ApplicationRecord
   validates :price_cap, presence: true
   validates :roster_size, presence: true
 
+  def cost_for(player:)
+    Players::CostCalculator.new(pricing_rules: [Players::ScalingPriceRule.new]).calculate_cost(player:, tournament:)
+  end
+
 end

--- a/app/services/players/cost_calculator.rb
+++ b/app/services/players/cost_calculator.rb
@@ -1,0 +1,20 @@
+module Players
+
+  class CostCalculator
+
+    attr_accessor :pricing_rules
+
+    def initialize(pricing_rules: [])
+      @pricing_rules = pricing_rules
+    end
+
+    def calculate_cost(player:, tournament:)
+      score = player.latest_score_before(date: tournament.starting_date)
+      cost = 0.00
+      pricing_rules.each { |rule| cost = rule.apply(score:, cost:) }
+      cost
+    end
+
+  end
+
+end

--- a/app/services/players/scaling_price_rule.rb
+++ b/app/services/players/scaling_price_rule.rb
@@ -1,0 +1,68 @@
+module Players
+
+  class ScalingPriceRule
+
+    attr_accessor :scales
+
+    def initialize(scales: default_scales)
+      @scales = scales
+    end
+
+    def apply(cost:, score:)
+      return cost unless score
+
+      apply_scales(cost:, score:)
+    end
+
+    def apply_scales(cost:, score:)
+      applicable_cost_scales(current_cost: cost).each do |scale|
+        while cost < scale[:maximum_cost]
+          break if score.negative? || score.zero?
+
+          point_rest = score - scale[:point_coefficient]
+          score -= scale[:point_coefficient]
+          cost += if point_rest.positive? || point_rest.zero?
+                    1.00
+                  else
+                    (scale[:point_coefficient] + point_rest) / scale[:point_coefficient]
+                  end
+        end
+      end
+      cost
+    end
+
+    def applicable_cost_scales(current_cost:)
+      scales.filter { |scale| scale[:maximum_cost].blank? || scale[:maximum_cost] >= current_cost }
+    end
+
+    def default_scales # rubocop:disable Metrics/MethodLength
+      [{
+        minimum_cost: 0,
+        maximum_cost: 10,
+        point_coefficient: 5.00
+      },
+       {
+         minimum_cost: 10,
+         maximum_cost: 25,
+         point_coefficient: 10.00
+       },
+       {
+         minimum_cost: 25,
+         maximum_cost: 40,
+         point_coefficient: 20.00
+       },
+       {
+         minimum_cost: 40,
+         maximum_cost: 50,
+         point_coefficient: 30.99
+       },
+       {
+         minimum_cost: 50,
+         maximum_cost: 999_999,
+         point_coefficient: 50.00
+       }]
+    end
+
+  end
+
+end

--- a/app/views/rosters/_player_table.html.erb
+++ b/app/views/rosters/_player_table.html.erb
@@ -2,11 +2,11 @@
 
 <div class="w-100 d-flex justify-content-end gap-3">
   <h4>Filters</h4>
-  <%= form_with(url: edit_game_roster_path(id: @roster.id, game: @game, page: params[:page]), method: :get, data: {turbo_stream: true }, class: 'd-flex gap-3 align-items-center') do |f| %>
+  <%= form_with(url: edit_game_roster_path(id: @roster.id, game: @game, page: params[:page]), method: :get, data: {turbo_stream: true, controller: "table-filters", 'table-filters-target': "form" }, class: 'd-flex gap-3 align-items-center') do |f| %>
     <%= f.label :country, t('activerecord.attributes.player.country') %>
-    <%= f.select :country, options_for_select(@countries, @filters[:country]), {}, { class: 'form-select w-25'} %>
+    <%= f.select :country, options_for_select(@countries, @filters[:country]), {}, { class: 'form-select w-25', onchange: "this.form.requestSubmit()" } %>
     <%= f.label :name, t('activerecord.attributes.player.name') %>
-    <%= f.text_field :name, value: @filters[:name], class: 'form-control w-100'  %>
+    <%= f.text_field :name, value: @filters[:name], class: 'form-control w-100', data: { 'table-filters-target': "input" }   %>
     <%= f.submit 'Filter', class: 'btn btn-secondary' %>
   <% end %>
 </div>
@@ -17,6 +17,7 @@
     <th><%= t("activerecord.attributes.player.name") %></th>
     <th><%= t("activerecord.attributes.player.country") %></th>
     <th><%= t("activerecord.attributes.player.external_points") %></th>
+    <th><%= t("activerecord.attributes.player.cost") %></th>
     <th><%= t("views.tables.actions") %></th>
   </tr>
   </thead>
@@ -31,6 +32,9 @@
       </td>
       <td>
         <%= player.current_score %>
+      </td>
+      <td>
+        <%= player.decorated_cost %>
       </td>
       <td>
         <% unless @roster.players.include?(player) %>

--- a/app/views/rosters/_roster.html.erb
+++ b/app/views/rosters/_roster.html.erb
@@ -1,12 +1,31 @@
 <% roster ||= @roster %>
+
 <div class="w-50 mx-auto p-2 my-3 bg-light text-dark">
   <h3><%= t('rosters.edit.roster_title') %></h3>
   <table class="table table-striped table-light">
+    <thead>
+    <tr>
+      <th>
+      </th>
+      <th>
+        <%= t('activerecord.attributes.player.external points') %>
+      </th>
+      <th>
+        <%= t('activerecord.attributes.player.cost') %>
+      </th>
+    </tr>
+    </thead>
     <% roster.reload.roster_players.each do |roster_player| %>
       <% player = roster_player.player %>
       <tr class="mx-2">
         <td>
-        <%= link_to(player.name, player.external_url ,target: "_blank") %> - <%= player.current_score %>
+        <%= link_to(player.name, player.external_url ,target: "_blank") %>
+        </td>
+        <td>
+          <%= player.current_score %>
+        </td>
+        <td>
+          <%= roster_player.decorated_player_cost %>
         </td>
         <td>
           <%= link_to t("rosters.edit.remove_player"), game_roster_path(id: roster.id, game: @game, page: params["page"], **@filters, roster: { roster_players_attributes: [{id: roster_player.id, _destroy: "1" }] } ), data: { 'turbo-method': :patch }, class: 'text-danger' %>
@@ -15,7 +34,27 @@
 
   <% end %>
   </table>
-  <div class="d-flex justify-content-end me-2"> <%= t('rosters.edit.roster_size') %> - <%= roster.players.count %></div>
+  <div class="d-flex justify-content-end">
+    <table class="w-50 table table-striped">
+      <tr>
+        <td>
+          <%= t('rosters.edit.roster_size') %>
+        </td>
+        <td>
+          <%= "#{roster.players.count} / #{roster.draft.roster_size}" %>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <%= t('rosters.edit.total_cost') %>
+        </td>
+        <td>
+          <%= "#{roster.total_cost} / #{roster.draft.price_cap}" %>
+        </td>
+      </tr>
+    </table>
+
+  </div>
 
   <% if @roster.errors %>
     <div class="text-danger">

--- a/app/views/salary_drafts/index.html.erb
+++ b/app/views/salary_drafts/index.html.erb
@@ -1,4 +1,4 @@
-<% if policy(:salary_draft).new? %>
+<% if current_user && policy(:salary_draft).new? %>
   <div class="d-flex p-2 m-2 w-100 justify-content-end">
     <%= link_to new_game_salary_draft_path(game: @game), class: 'btn btn-success' do %>
       <%= t(".add") %>

--- a/app/views/salary_drafts/show.html.erb
+++ b/app/views/salary_drafts/show.html.erb
@@ -1,4 +1,4 @@
-<% if policy(@salary_draft).edit? || policy(@salary_draft).destroy?  %>
+<% if current_user %>
   <div class="d-flex p-2 m-2 w-100 justify-content-end gap-3">
     <% if policy(@salary_draft).edit? %>
       <%= link_to edit_game_salary_draft_path(@salary_draft, game: @game), class: 'btn btn-success' do %>
@@ -35,7 +35,7 @@
     </tr>
   </table>
   <div class="d-flex p-2 m-2 w-100 justify-content-end gap-3">
-  <% if policy(Participation.new(user: current_user, draft: @salary_draft)).create? %>
+  <% if current_user && policy(Participation.new(user: current_user, draft: @salary_draft)).create? %>
     <%= link_to game_participations_path(game: @game, participation: {draft_id: @salary_draft.id, user_id: current_user.id}), data: {  'turbo-method': :post }, class: 'btn btn-success' do %>
       <%= t(".add_participation") %>
     <% end %>

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -25,6 +25,7 @@ en:
         country: Country
         external_id: External id
         external_points: External points
+        cost: Cost
         game_id: Game
       tournament:
         name: Name
@@ -55,7 +56,8 @@ en:
         roster:
           attributes:
             players:
-              roster_too_big: This roster is full
+              roster_too_big: This roster is full.
+              total_cost_exceeded: Price cap exceeded. Please remove players before adding the selected player.
   games:
     not_found: Game not found. Please select a valid game to continue.
   pages:

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -39,6 +39,7 @@ en:
     edit:
       roster_title: Current roster
       roster_size: Player count
+      total_cost: Total cost
       players: Players
       add_player: Add player
       remove_player: Remove

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "esbuild": "^0.21.5",
     "husky": "^9.0.11",
     "jquery": "^3.7.1",
+    "lodash.debounce": "^4.0.8",
     "sass": "^1.77.0"
   },
   "scripts": {

--- a/spec/controllers/rosters_controller_spec.rb
+++ b/spec/controllers/rosters_controller_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe RostersController do
+  let(:game) { create(:game, id: 'PTCG') }
+  let(:user) { create(:user) }
+  let(:participation) { create(:participation, user:) }
+
+  describe '#edit' do
+    let(:roster) { create(:roster, participation:) }
+
+    before do
+      sign_in user
+    end
+
+    it 'applies the cost to all available players' do
+      player1, player2 = create_list(:player, 2, :without_scores, game:)
+      player1.external_scores.create(score: 50)
+      player2.external_scores.create(score: 200)
+      get :edit, params: { id: roster.id, game: game.id }
+      expect(assigns(:players).map(&:cost)).to include(10.0, 25.0)
+    end
+
+    context 'when filtering the players' do
+      context 'when filtering for country'  do
+        it 'shows only the country specific players' do
+          player1, player2 = create_list(:player, 2, game:, country: 'BE')
+          player3 = create(:player, game:, country: 'FR')
+          get :edit, params: { id: roster.id, game: game.id, country: 'BE' }
+          expect(assigns(:players)).to include(player1, player2)
+          expect(assigns(:players)).not_to include(player3)
+        end
+      end
+
+      context 'when filtering for name' do
+        it 'shows only the players with a like name' do
+          player1 = create(:player, game:, name: 'Sen')
+          player2 = create(:player, game:, name: 'Pedersen')
+          player3 = create(:player, game:, name: 'Karel')
+          get :edit, params: { id: roster.id, game: game.id, name: 'sen' }
+          expect(assigns(:players)).to include(player1, player2)
+          expect(assigns(:players)).not_to include(player3)
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/players.rb
+++ b/spec/factories/players.rb
@@ -9,5 +9,11 @@ FactoryBot.define do
     after(:build) do |player, _context|
       player.external_scores << build(:external_score, player:)
     end
+
+    trait :without_scores do
+      after(:build) do |player, _context|
+        player.external_scores = []
+      end
+    end
   end
 end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -17,4 +17,16 @@ RSpec.describe Player do
       expect(current_score).not_to eq(old_score)
     end
   end
+
+  describe '#latest_score_before' do
+    let(:player) { create(:player) }
+
+    it 'reflects the most recent score for the player before the given date' do
+      player.current_score
+      date = 5.days.ago
+      latest_score = create(:external_score, player:, created_at: 10.days.ago)
+      player.reload
+      expect(player.latest_score_before(date:)).to eq(latest_score.score)
+    end
+  end
 end

--- a/spec/models/roster_player_spec.rb
+++ b/spec/models/roster_player_spec.rb
@@ -3,4 +3,17 @@ require 'rails_helper'
 RSpec.describe RosterPlayer do
   it { is_expected.to belong_to(:roster) }
   it { is_expected.to belong_to(:player) }
+
+  describe '#player_cost' do
+    let(:player) { create(:player, :without_scores) }
+    let(:draft) { create(:salary_draft) }
+    let(:participation) { create(:participation, draft:) }
+    let(:roster) { create(:roster, participation:) }
+    let(:roster_player) { create(:roster_player, player:, roster:) }
+
+    it "reflects the player's cost for the roster's draft" do
+      create(:external_score, player:, score: 500)
+      expect(roster_player.player_cost).to eq(40.0)
+    end
+  end
 end

--- a/spec/models/salary_draft_spec.rb
+++ b/spec/models/salary_draft_spec.rb
@@ -5,4 +5,14 @@ RSpec.describe SalaryDraft do
   it { is_expected.to validate_presence_of(:price_cap) }
   it { is_expected.to belong_to(:tournament) }
   it { is_expected.to have_many(:participations) }
+
+  describe '#cost_for' do
+    let(:player) { create(:player, :without_scores) }
+    let(:draft) { create(:salary_draft) }
+
+    it 'reflects the cost for the player for the related tournament' do
+      create(:external_score, player:, score: 500)
+      expect(draft.cost_for(player:)).to eq(40.0)
+    end
+  end
 end

--- a/spec/services/players/cost_calculator_spec.rb
+++ b/spec/services/players/cost_calculator_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+module Players
+
+  RSpec.describe CostCalculator do
+    describe '#calculate_cost' do
+      let(:tournament) { create(:tournament) }
+      let(:player) do
+        player = create(:player, :without_scores)
+        create(:external_score, score: 50, player:)
+        player
+      end
+
+      where(:price_rules, :expected_cost) do
+        [
+          [[], 0.0],
+          [[ScalingPriceRule.new], 10.0],
+          [[ScalingPriceRule.new(scales: [
+                                   {
+                                     minimum_cost: 0,
+                                     maximum_cost: 20,
+                                     point_coefficient: 2.00
+                                   }
+                                 ])], 20.0]
+        ]
+      end
+
+      with_them do
+        subject { described_class.new(pricing_rules: price_rules).calculate_cost(player:, tournament:) }
+
+        it { is_expected.to eq(expected_cost) }
+      end
+    end
+  end
+
+end

--- a/spec/services/players/scaling_price_rule_spec.rb
+++ b/spec/services/players/scaling_price_rule_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+module Players
+
+  RSpec.describe ScalingPriceRule do
+    describe '#apply' do
+      let(:player) { create(:player) }
+
+      context 'when applying the default scales' do
+        where(:current_cost, :score, :expected_cost) do
+          [
+            [0, 120, 17.00],
+            [0, 250,  27.50],
+            [13, 100, 23.00],
+            [25, 100, 30.00]
+          ]
+        end
+
+        with_them do
+          before do
+            create(:external_score, player:, score:)
+          end
+
+          it 'applies the price scales whose minimum cost is met' do
+            cost = described_class.new.apply(cost: current_cost, score: player.current_score)
+            expect(cost).to eq(expected_cost)
+          end
+        end
+      end
+    end
+  end
+
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -277,6 +277,11 @@ jquery@^3.7.1:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
   integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
 
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
+
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"


### PR DESCRIPTION
The logic allows for extension with price rules but for now applies a default scaling price rule as discussed for the beta