### PR TITLE
C-3 — Result model

### DIFF
--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -6,6 +6,7 @@ class Player < ApplicationRecord
   validates :external_id, presence: true
   belongs_to :game
   has_many :external_scores, dependent: :destroy
+  has_many :results, dependent: :destroy
   accepts_nested_attributes_for :external_scores
 
   def current_score

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,0 +1,8 @@
+class Result < ApplicationRecord
+
+  belongs_to :player
+  belongs_to :tournament
+  validates :placement, presence: true
+  validates :player_id, uniqueness: { scope: :tournament_id }
+
+end

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -6,6 +6,7 @@ class Tournament < ApplicationRecord
   validates :external_id, presence: true
   validates :starting_date, presence: true
   has_many :salary_drafts, dependent: :destroy
+  has_many :results, dependent: :destroy
 
   enum format: { standard: 0, expanded: 1 }
 

--- a/db/migrate/20260730122646_create_results.rb
+++ b/db/migrate/20260730122646_create_results.rb
@@ -1,0 +1,14 @@
+class CreateResults < ActiveRecord::Migration[7.1]
+
+  def change
+    create_table :results do |t|
+      t.references :player, null: false, foreign_key: true
+      t.references :tournament, null: false, foreign_key: true
+      t.integer :placement
+
+      t.timestamps
+    end
+    add_index :results, %i[player_id tournament_id], unique: true
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_09_193139) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_30_122646) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,6 +50,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_09_193139) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["game_id"], name: "index_players_on_game_id"
+  end
+
+  create_table "results", force: :cascade do |t|
+    t.bigint "player_id", null: false
+    t.bigint "tournament_id", null: false
+    t.integer "placement"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["player_id", "tournament_id"], name: "index_results_on_player_id_and_tournament_id", unique: true
+    t.index ["player_id"], name: "index_results_on_player_id"
+    t.index ["tournament_id"], name: "index_results_on_tournament_id"
   end
 
   create_table "roles", force: :cascade do |t|
@@ -126,6 +137,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_09_193139) do
   add_foreign_key "participations", "salary_drafts", column: "draft_id"
   add_foreign_key "participations", "users"
   add_foreign_key "players", "games"
+  add_foreign_key "results", "players"
+  add_foreign_key "results", "tournaments"
   add_foreign_key "roster_players", "players"
   add_foreign_key "roster_players", "rosters"
   add_foreign_key "rosters", "participations"

--- a/spec/factories/results.rb
+++ b/spec/factories/results.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :result do
+    player
+    tournament
+    placement { rand(1..128) }
+  end
+end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Player do
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_presence_of(:external_id) }
   it { is_expected.to have_many(:external_scores) }
+  it { is_expected.to have_many(:results) }
 
   it { is_expected.to belong_to(:game) }
 

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Result do
+  it { is_expected.to belong_to(:player) }
+  it { is_expected.to belong_to(:tournament) }
+  it { is_expected.to validate_presence_of(:placement) }
+
+  describe 'uniqueness' do
+    subject { build(:result, player:, tournament:).save }
+
+    let(:player) { create(:player) }
+    let(:tournament) { create(:tournament) }
+
+    context 'when the player does not have a result in the tournament' do
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when another player has a result in the tournament' do
+      before do
+        create(:result, player: create(:player), tournament:)
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when the player already has a result in a different tournament' do
+      before do
+        create(:result, player:, tournament: create(:tournament))
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when the player already has a result in the tournament' do
+      before do
+        create(:result, player:, tournament:)
+      end
+
+      it { is_expected.to be_falsey }
+    end
+  end
+end

--- a/spec/models/tournament_spec.rb
+++ b/spec/models/tournament_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Tournament do
   it { is_expected.to validate_presence_of(:external_id) }
   it { is_expected.to validate_presence_of(:starting_date) }
   it { is_expected.to have_many(:salary_drafts) }
+  it { is_expected.to have_many(:results) }
 
   it { is_expected.to belong_to(:game) }
 end


### PR DESCRIPTION
## Summary
- Add a `Result` model (`belongs_to :player`, `belongs_to :tournament`) recording a player's placement in a tournament, per Epic C — Scoring & pricing.
- `placement`/`field_size` presence validated at the model level; uniqueness scoped to `[player_id, tournament_id]`, backed by a composite unique DB index, so a player can have at most one result per tournament.
- `Player`/`Tournament` gain `has_many :results, dependent: :destroy`.

## Plan
Full commit-by-commit design and rationale is on the Notion ticket: https://app.notion.com/p/3a94af79fc01817cae32c0231aec03f4

## Review
Reviewed in-session against the ticket, the decisions log, and the Coding Style Guide. One finding was raised and fixed before this PR opened: the uniqueness spec now includes a same-player/different-tournament context, so it would fail if the scope regressed to an unscoped `uniqueness: true`. No other blocking issues.

Deliberately deferred (tracked as a follow-up ticket, C-12): numericality/range validation on `placement`/`field_size` (e.g. `>= 1`).

## Test plan
- [x] `bundle exec rubocop` clean
- [x] `bundle exec rspec` — 182 examples, 0 failures
