### PR TITLE
Add ticket-pipeline skill + test environment SessionStart hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -84,4 +84,19 @@ if command -v bundle >/dev/null 2>&1; then
   RAILS_ENV=test bundle exec rails db:prepare >/dev/null 2>&1 || true
 fi
 
+# 7. Coding Style Guide reminder. This hook can't fetch Notion content itself
+# (no API credentials available to the shell — Notion access only exists
+# inside the agent's own tool calls), so instead it surfaces the canonical
+# page reference from .claude/coding-style.json as context, telling the
+# agent to pull it in as one of its first actions. Printed on stdout so
+# Claude Code injects it into the session's context.
+if [ -f .claude/coding-style.json ]; then
+  STYLE_GUIDE_URL=$(grep -o '"notion_page_url"[[:space:]]*:[[:space:]]*"[^"]*"' .claude/coding-style.json | sed -E 's/.*"([^"]+)"$/\1/')
+  if [ -n "$STYLE_GUIDE_URL" ]; then
+    cat <<EOF
+Before making code changes in this repo, fetch the Coding Style Guide from Notion ($STYLE_GUIDE_URL) via the notion-fetch tool and treat its Style Rules as binding project style guidance alongside repo conventions — it's the shared source of truth the ticket-pipeline skill also reads before implementing tickets. Skip this fetch only if Notion tools are unavailable this session.
+EOF
+  fi
+fi
+
 exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -38,6 +38,12 @@ if [ -n "${TCG_FANTASY_LEAGUE_GIT_SIGNING_KEY:-}" ]; then
   git config gpg.format ssh
   git config user.signingkey "$SIGNING_KEY_PATH"
   git config commit.gpgsign true
+  # This environment's own global gitconfig points gpg.ssh.program at a
+  # platform-managed signer (/tmp/code-sign, tied to Claude's own identity)
+  # that silently ignores a custom user.signingkey — it neither errors nor
+  # produces a valid signature for it. Override it repo-locally to plain
+  # ssh-keygen so the key above actually gets used.
+  git config gpg.ssh.program "$(command -v ssh-keygen)"
 fi
 
 # 2. Postgres: install if missing, relax local auth to trust (throwaway

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Prepares the test environment (Rails credentials, Postgres, gems, JS assets,
+# test DB schema) so `bundle exec rspec` / `bundle exec rubocop` work without
+# manual setup. Every step is best-effort: a failure here shouldn't block the
+# session from starting, it should just leave the old (manual-setup) friction
+# in place.
+set -uo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+# 1. Rails test credentials key, from the TCG_FANTASY_LEAGUE_TEST_KEY secret.
+# Lets Rails decrypt the already-committed config/credentials/test.yml.enc
+# instead of needing a throwaway local key regenerated every session.
+if [ -n "${TCG_FANTASY_LEAGUE_TEST_KEY:-}" ] && [ ! -f config/credentials/test.key ]; then
+  mkdir -p config/credentials
+  printf '%s' "$TCG_FANTASY_LEAGUE_TEST_KEY" > config/credentials/test.key
+  chmod 600 config/credentials/test.key
+fi
+
+# 2. Postgres: install if missing, relax local auth to trust (throwaway
+# container, local-socket-only, fine for a test DB), start the service.
+export DEBIAN_FRONTEND=noninteractive
+if ! command -v pg_config >/dev/null 2>&1 || ! command -v psql >/dev/null 2>&1; then
+  sudo apt-get update -qq || true
+  sudo apt-get install -y -qq postgresql libpq-dev || true
+fi
+
+sudo service postgresql start >/dev/null 2>&1 || true
+
+PG_HBA=$(sudo -u postgres psql -tAc 'SHOW hba_file;' 2>/dev/null | tr -d '[:space:]')
+if [ -n "$PG_HBA" ] && sudo test -f "$PG_HBA"; then
+  sudo sed -i -E 's/^(local[[:space:]]+all[[:space:]]+all[[:space:]]+)\S+/\1trust/' "$PG_HBA" || true
+  sudo service postgresql restart >/dev/null 2>&1 || true
+fi
+
+# 3. Ruby gems.
+if command -v bundle >/dev/null 2>&1; then
+  bundle install --quiet || true
+fi
+
+# 3b. Work around a PATH quirk in this environment: rbenv installs gem
+# executables (rubocop, rspec, rails, ...) under the Ruby install's bin/, but
+# `bundle exec` only looks in GEM_HOME/bin, so `bundle exec rubocop` fails
+# with "command not found" even though the gem is installed. Symlinking fixes
+# it for both our own commands and the repo's husky pre-commit hook.
+RBENV_BIN="$(rbenv prefix 2>/dev/null)/bin"
+GEM_BIN="$(ruby -e 'puts Gem.dir' 2>/dev/null)/bin"
+if [ -d "$RBENV_BIN" ] && [ -n "$GEM_BIN" ]; then
+  mkdir -p "$GEM_BIN"
+  for f in "$RBENV_BIN"/*; do
+    name="$(basename "$f")"
+    [ -e "$GEM_BIN/$name" ] || ln -s "$f" "$GEM_BIN/$name"
+  done
+fi
+
+# 4. Create/update the local Postgres role to match the decrypted test
+# credentials, so `bin/rails db:*` and specs can actually connect.
+if [ -f config/credentials/test.key ] && command -v bundle >/dev/null 2>&1; then
+  DB_INFO=$(RAILS_ENV=test bundle exec rails runner \
+    'creds = Rails.application.credentials.db; puts [creds.username, creds.password].join("\t")' \
+    2>/dev/null || true)
+  DB_USER=$(printf '%s' "$DB_INFO" | cut -f1)
+  DB_PASS=$(printf '%s' "$DB_INFO" | cut -f2)
+  if [ -n "$DB_USER" ]; then
+    sudo -u postgres psql -v ON_ERROR_STOP=0 -c \
+      "DO \$\$ BEGIN CREATE ROLE \"$DB_USER\" WITH LOGIN SUPERUSER PASSWORD '$DB_PASS'; EXCEPTION WHEN duplicate_object THEN NULL; END \$\$;" \
+      >/dev/null 2>&1 || true
+  fi
+fi
+
+# 5. JS assets — request specs 404 on application.css/js without this.
+if [ -f package.json ] && command -v yarn >/dev/null 2>&1; then
+  yarn install --silent || true
+  yarn build >/dev/null 2>&1 || true
+  yarn build:css >/dev/null 2>&1 || true
+fi
+
+# 6. Test DB schema.
+if command -v bundle >/dev/null 2>&1; then
+  RAILS_ENV=test bundle exec rails db:prepare >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -21,6 +21,25 @@ if [ -n "${TCG_FANTASY_LEAGUE_TEST_KEY:-}" ] && [ ! -f config/credentials/test.k
   chmod 600 config/credentials/test.key
 fi
 
+# 1b. Git commit signing (SSH), from the TCG_FANTASY_LEAGUE_GIT_SIGNING_KEY
+# secret. Writes the private key to a session-local file and configures
+# repo-local SSH commit signing so pushed commits show as "Verified" on
+# GitHub. Skipped (not a failure) if the secret isn't set — commits just
+# stay unsigned, same as before this was added.
+if [ -n "${TCG_FANTASY_LEAGUE_GIT_SIGNING_KEY:-}" ]; then
+  if ! command -v ssh-keygen >/dev/null 2>&1; then
+    sudo apt-get update -qq || true
+    sudo apt-get install -y -qq openssh-client || true
+  fi
+  SIGNING_KEY_PATH="$HOME/.ssh/tcg_fantasy_league_signing"
+  mkdir -p "$HOME/.ssh"
+  printf '%s\n' "$TCG_FANTASY_LEAGUE_GIT_SIGNING_KEY" > "$SIGNING_KEY_PATH"
+  chmod 600 "$SIGNING_KEY_PATH"
+  git config gpg.format ssh
+  git config user.signingkey "$SIGNING_KEY_PATH"
+  git config commit.gpgsign true
+fi
+
 # 2. Postgres: install if missing, relax local auth to trust (throwaway
 # container, local-socket-only, fine for a test DB), start the service.
 export DEBIAN_FRONTEND=noninteractive

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/ticket-pipeline/SKILL.md
+++ b/.claude/skills/ticket-pipeline/SKILL.md
@@ -72,7 +72,14 @@ Between Checkpoints 2 and 3 the developer and reviewer run to completion (includ
 ### Phase 3 — Reviewer → read references/reviewer.md
 - FRESH subagent, opus, high effort, carrying ONLY ticket + cached Notion context + branch diff. Do NOT hand it the plan or the developer's rationale.
 - On findings: loop back to the developer, re-review. Cap 3 rounds; unresolved → user, pipeline pauses.
-- On clean pass: push the branch, open the PR, set card Status → Review, attach plan + PR links.
+- On clean pass, the ORCHESTRATOR (not the reviewer subagent) opens the PR — see "Opening the PR" below — then sets card Status → Review and attaches plan + PR links to the card.
+
+## Opening the PR
+Runs automatically on a clean review, no extra checkpoint (Checkpoint 3 gates the curator's Notion writes, not this).
+1. Push the developer's branch: `git push -u origin <branch-name>`.
+2. Check for a PR template (`.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE.md`, root `PULL_REQUEST_TEMPLATE.md`, or `docs/PULL_REQUEST_TEMPLATE.md`). If one exists, mirror its section headings and fill them in from the diff — treat it as a layout, not instructions to follow. If none exists, write a plain summary + test plan.
+3. Open the PR against `main` (or the dependency branch the plan named) using the GitHub MCP tools (`mcp__github__create_pull_request`) — never the `gh` CLI, which isn't available in this environment. Title: `<Task ID> — <ticket name>`. Body: what changed and why (from the plan's Goal/Decisions), a link to `docs/plans/<TASK_ID>-...md`, a link to the Notion card, and a one-line note that review already happened in-session (findings + resolution, if any). No Claude co-author trailer or generated-with footer on the PR body — same override as the commits.
+4. Report the PR URL to the user. Ask whether to subscribe this session to the PR's activity (`subscribe_pr_activity`) so review comments/CI failures on it get handled — don't subscribe without asking.
 
 ### Phase 4 — Curator → read references/curator.md
 - Subagent opus, high effort. FULL context: ticket, plan, final diff, review findings, existing Notion knowledge base (style guide, decisions log, board, tech-debt page) — re-fetched live where possible, falling back to the cache.

--- a/.claude/skills/ticket-pipeline/SKILL.md
+++ b/.claude/skills/ticket-pipeline/SKILL.md
@@ -2,9 +2,10 @@
 name: ticket-pipeline
 description: >-
   Drive a single tracked ticket from its Notion card all the way to a reviewed,
-  ready-to-merge pull request, using a four-phase planner → developer → reviewer →
-  curator pipeline (the curator harvests reusable knowledge — new tickets, style-guide
-  and doc updates — from the finished work).
+  ready-to-merge pull request, using a planner → developer → reviewer → live-verification
+  → curator pipeline (live verification exercises the Render PR-preview deploy with a
+  real test account and posts screenshot evidence; the curator harvests reusable
+  knowledge — new tickets, style-guide and doc updates — from the finished work).
   Use this skill whenever the user wants to "work", "pick up", "start",
   "ship", or "rattle through" a ticket/story/card — especially when they reference
   a ticket ID (like A-1, C-3), a Notion board card, or a backlog item — even if
@@ -16,12 +17,13 @@ description: >-
 
 # Ticket pipeline
 
-Take one ticket and carry it, in order, through four specialist phases:
+Take one ticket and carry it, in order, through five specialist phases:
 
 1. Planner (Opus, high effort) — understands the ticket, closes knowledge gaps with you, and writes a commit-by-commit plan directly onto the Notion ticket card.
 2. Developer (Sonnet, medium effort) — builds it test-first on a branch, following the coding style guide, linting and testing before every commit.
 3. Reviewer (Opus, high effort) — reviews the whole branch against ONLY the ticket, the style guide, and Notion docs, blind to the developer's reasoning, and loops fixes back before the PR opens.
-4. Curator (Opus, high effort) — after review, harvests what the work revealed: proposes new tickets, style-guide additions, or docs, and files them on approval.
+4. Tester (Sonnet, medium effort) — once Render's PR-preview environment deploys, exercises the ticket's done-criteria against the live app with a real test account, capturing screenshots as evidence.
+5. Curator (Opus, high effort) — after review, harvests what the work revealed: proposes new tickets, style-guide additions, or docs, and files them on approval.
 
 Each role runs as a SEPARATE subagent on purpose. Isolation matters most for the reviewer — it must not inherit the developer's justifications, or it will rubber-stamp them. The curator is the deliberate exception: it needs the whole picture.
 
@@ -42,12 +44,19 @@ git config user.email "64021036+Vinnehboom@users.noreply.github.com"
 ```
 Set this repo-locally (not `--global`) at the start of Phase 2, before the first commit. The noreply address is what links commits to the `Vinnehboom` GitHub account in the UI without exposing a personal email — don't substitute a real email address here. See references/developer.md.
 
+## Live-verification credentials
+The tester (Phase 4) logs into the Render PR-preview app as a real user. Credentials come from environment secrets, never hardcoded in the skill or the repo:
+- `TCG_FANTASY_LEAGUE_STAGING_TEST_EMAIL`
+- `TCG_FANTASY_LEAGUE_STAGING_TEST_PASSWORD`
+
+If either is unset, skip Phase 4 entirely and say so — don't attempt unauthenticated testing as a substitute, and don't ask the user to paste credentials into the conversation. Never print, log, or screenshot the password; the email appearing in a screenshot (e.g. an account page) is fine, it's a test account.
+
 ## Caching Notion context at init (robustness fix — do this first, every run)
 
 Notion MCP has previously dropped mid-run and blinded the developer/reviewer/curator (they fell back to guessing repo conventions instead of the style guide). To make a Notion disconnect mid-pipeline harmless:
 
 1. As the FIRST action of any pipeline run, fetch every doc phases will need — the ticket card, the project context/decisions page, and the Coding Style Guide — and write each one verbatim to a local cache file under `docs/pipeline-cache/<TASK_ID>/` (e.g. `ticket.md`, `context.md`, `style-guide.md`). Create the directory if needed.
-2. From then on, every subagent (planner, developer, reviewer, curator) is handed the LOCAL CACHE FILES, not a live Notion fetch. Subagents should not need `mcp__Notion__*` tools at all except the curator, which re-fetches live at Phase 4 specifically to check proposals against the current state of the docs before proposing (see references/curator.md) — if that live re-fetch fails, it falls back to the cached copies and says so.
+2. From then on, every subagent (planner, developer, reviewer, curator) is handed the LOCAL CACHE FILES, not a live Notion fetch. Subagents should not need `mcp__Notion__*` tools at all except the curator, which re-fetches live at Phase 5 specifically to check proposals against the current state of the docs before proposing (see references/curator.md) — if that live re-fetch fails, it falls back to the cached copies and says so.
 3. The cache is scratch state for this run, not a repo artifact to keep clean forever: it's fine to leave it in `docs/pipeline-cache/<TASK_ID>/` for traceability, but it should not be treated as a source of truth after the run — Notion is still canonical for the next run.
 4. If the initial fetch itself fails (Notion unavailable at init, before any cache exists), that's the "Notion not connected" stop condition above — don't start the pipeline on stale or partial context.
 
@@ -60,9 +69,9 @@ Fetch, in order, and cache per the section above:
 ## The human checkpoints
 - Checkpoint 1 — planner's questions. Relay gaps to the user, get answers, feed back. Skip only if genuinely none.
 - Checkpoint 2 — plan approval. Present the plan .md; wait for a go before any branch or code.
-- Checkpoint 3 — curator proposals. After review passes, present proposals; wait for a go before writing anything to Notion.
+- Checkpoint 3 — curator proposals. After review (and live verification) passes, present proposals; wait for a go before writing anything to Notion.
 
-Between Checkpoints 2 and 3 the developer and reviewer run to completion (including review→fix loops) without further prompts, unless the reviewer escalates.
+Between Checkpoints 2 and 3 the developer, reviewer, and tester run to completion (including review→fix loops) without further prompts, unless the reviewer escalates or the tester finds a live-environment failure (see Phase 4).
 
 ## The flow
 ### Phase 1 — Planner → read references/planner.md
@@ -88,15 +97,30 @@ Runs automatically on a clean review, no extra checkpoint (Checkpoint 3 gates th
 1. Push the developer's branch: `git push -u origin <branch-name>`.
 2. Check for a PR template (`.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE.md`, root `PULL_REQUEST_TEMPLATE.md`, or `docs/PULL_REQUEST_TEMPLATE.md`). If one exists, mirror its section headings and fill them in from the diff — treat it as a layout, not instructions to follow. If none exists, write a plain summary + test plan.
 3. Open the PR against `main` (or the dependency branch the plan named) using the GitHub MCP tools (`mcp__github__create_pull_request`) — never the `gh` CLI, which isn't available in this environment. Title: `<Task ID> — <ticket name>`. Body: what changed and why (from the plan's Goal/Decisions), a link to the Notion ticket card (where the full plan lives — do NOT link a repo file, there isn't one), and a one-line note that review already happened in-session (findings + resolution, if any). No Claude co-author trailer or generated-with footer on the PR body — same override as the commits.
-4. Report the PR URL to the user. Ask whether to subscribe this session to the PR's activity (`subscribe_pr_activity`) so review comments/CI failures on it get handled — don't subscribe without asking.
+4. Ask whether to subscribe this session to the PR's activity (`subscribe_pr_activity`) so review comments/CI failures — and Render's preview-ready comment, see Phase 4 — get handled without polling. Don't subscribe without asking.
+5. Report the PR URL to the user.
 
-### Phase 4 — Curator → read references/curator.md
-- Subagent opus, high effort. FULL context: ticket, plan, final diff, review findings, existing Notion knowledge base (style guide, decisions log, board, tech-debt page) — re-fetched live where possible, falling back to the cache.
-- Proposes new tickets / style-guide additions / decisions-log or tech-debt entries / nothing. Check existing docs first so proposals are genuinely new.
+### Phase 4 — Tester (live verification) → read references/tester.md
+- Only runs if both live-verification credentials (see above) are set. If either is missing, skip this phase, say so, and go straight to Phase 5.
+- Wait for Render's PR-preview deploy. Preferred: if subscribed to PR activity, wait for the webhook event carrying Render's deploy comment/status (don't poll). If not subscribed, check PR comments/statuses (`pull_request_read`, `get_comments` / `get_status`) for a URL matching a Render preview host, on a real wait mechanism (`ScheduleWakeup` or `send_later`) rather than an inline sleep loop. Give up after ~20 minutes, tell the user the preview never showed up, and skip to Phase 5.
+- FRESH subagent, sonnet, medium effort, with Playwright (Chromium is pre-installed in this environment — do not run `playwright install`). Given: the ticket's done-criteria, the preview URL, and the two credential env vars (read at runtime, never pasted into the prompt or written to a file).
+- Logs in as the test account, walks the ticket's done-criteria one by one against the live preview, screenshots each meaningful step, and notes pass/fail/observation per criterion. Read-only where possible; where the criterion requires creating data, prefer data that's obviously a test fixture (e.g. an obviously-named record) over mutating anything that looks like real seed data.
+- Hands back: a short markdown report (done-criteria → pass/fail/observation) plus the screenshot files. Never includes the password in the report.
+- The ORCHESTRATOR posts the report + screenshots to BOTH the PR (as a comment) and the Notion ticket card (as an attachment/section) — see "Posting live-verification evidence" below.
+- A live-environment failure here is NOT one of the reviewer's 3 rounds — it's a separate signal. Report it to the user; don't silently fix-and-retry the same way the reviewer loop does, since this is evidence about the deployed app, not a code review finding the developer can just address blindly.
+
+## Posting live-verification evidence
+1. PR comment: post the tester's markdown report via the GitHub MCP comment tools, with screenshots attached (upload via the same mechanism used elsewhere for PR comment images in this environment; if none exists, describe the screenshot and attach the file so the user can view it, rather than silently dropping it).
+2. Notion card: append a `## Live verification` section to the ticket card (`notion-update-page`, `insert_content`) with the same report; attach screenshots via `notion-create-attachment` if available, otherwise reference where the files can be found.
+3. Both postings carry the same attribution footer convention as other GitHub posts in this environment (see repo-level instructions) — the Notion posting does not need one.
+
+### Phase 5 — Curator → read references/curator.md
+- Subagent opus, high effort. FULL context: ticket, plan, final diff, review findings, live-verification report (if Phase 4 ran), existing Notion knowledge base (style guide, decisions log, board, tech-debt page) — re-fetched live where possible, falling back to the cache.
+- Proposes new tickets / style-guide additions / decisions-log or tech-debt entries / nothing. Check existing docs first so proposals are genuinely new. A live-verification failure that couldn't be resolved in-session is exactly the kind of thing worth a follow-up ticket.
 - Checkpoint 3: present proposals; on approval, create cards / edit pages. Nothing written without the user's go.
 
 ## Model and effort summary
-Planner opus/high; Developer sonnet/medium; Reviewer opus/high; Curator opus/high. If a model isn't available, fall back to the closest stronger model and say so rather than silently downgrading the reviewer.
+Planner opus/high; Developer sonnet/medium; Reviewer opus/high; Tester sonnet/medium; Curator opus/high. If a model isn't available, fall back to the closest stronger model and say so rather than silently downgrading the reviewer.
 
 ## Notion status transitions
 Planner starts → In progress. PR opened after clean review → Review. Leave Done for a human on merge. If a phase fails or the user aborts, return the card to its previous status and say what happened.
@@ -105,3 +129,4 @@ Planner starts → In progress. PR opened after clean review → Review. Leave D
 - One ticket per run. Repeat the pipeline per ticket; offer to continue after a PR opens.
 - Respect dependencies. If Depends On isn't satisfied, flag at Checkpoint 1.
 - Don't skip review isolation. Reusing the developer as reviewer, or pasting the plan into the reviewer, defeats the design.
+- Never hardcode the live-verification credentials anywhere (skill files, commits, PR bodies, Notion pages, logs) — env vars only, read at the point of use.

--- a/.claude/skills/ticket-pipeline/SKILL.md
+++ b/.claude/skills/ticket-pipeline/SKILL.md
@@ -3,9 +3,11 @@ name: ticket-pipeline
 description: >-
   Drive a single tracked ticket from its Notion card all the way to a reviewed,
   ready-to-merge pull request, using a planner → developer → reviewer → live-verification
-  → curator pipeline (live verification exercises the Render PR-preview deploy with a
-  real test account and posts screenshot evidence; the curator harvests reusable
-  knowledge — new tickets, style-guide and doc updates — from the finished work).
+  → gatekeeper → curator pipeline (live verification exercises the Render PR-preview
+  deploy with a real test account and posts screenshot evidence; the gatekeeper keeps
+  the PR a draft — CI green, evidence attached, branch rebased onto main, never merged —
+  until it's genuinely ready for human review; the curator harvests reusable knowledge —
+  new tickets, style-guide and doc updates — from the finished work).
   Use this skill whenever the user wants to "work", "pick up", "start",
   "ship", or "rattle through" a ticket/story/card — especially when they reference
   a ticket ID (like A-1, C-3), a Notion board card, or a backlog item — even if
@@ -17,15 +19,16 @@ description: >-
 
 # Ticket pipeline
 
-Take one ticket and carry it, in order, through five specialist phases:
+Take one ticket and carry it, in order, through six specialist phases:
 
 1. Planner (Opus, high effort) — understands the ticket, closes knowledge gaps with you, and writes a commit-by-commit plan directly onto the Notion ticket card.
 2. Developer (Sonnet, medium effort) — builds it test-first on a branch, following the coding style guide, linting and testing before every commit.
 3. Reviewer (Opus, high effort) — reviews the whole branch against ONLY the ticket, the style guide, and Notion docs, blind to the developer's reasoning, and loops fixes back before the PR opens.
 4. Tester (Sonnet, medium effort) — once Render's PR-preview environment deploys, exercises the ticket's done-criteria against the live app with a real test account, capturing screenshots as evidence.
-5. Curator (Opus, high effort) — after review, harvests what the work revealed: proposes new tickets, style-guide additions, or docs, and files them on approval.
+5. Gatekeeper (orchestrator-run, no separate subagent) — keeps the PR a draft until CI is green, testing evidence is attached, and the branch is rebased onto the latest main (never merged) — only then marks it ready for review.
+6. Curator (Opus, high effort) — after review, harvests what the work revealed: proposes new tickets, style-guide additions, or docs, and files them on approval.
 
-Each role runs as a SEPARATE subagent on purpose. Isolation matters most for the reviewer — it must not inherit the developer's justifications, or it will rubber-stamp them. The curator is the deliberate exception: it needs the whole picture.
+Each role runs as a SEPARATE subagent on purpose (except the Gatekeeper, which is mechanical orchestrator work, not judgment work — see Phase 5). Isolation matters most for the reviewer — it must not inherit the developer's justifications, or it will rubber-stamp them. The curator is the deliberate exception: it needs the whole picture.
 
 The ORCHESTRATOR (you, running this skill) owns the flow between phases, the three human checkpoints, and keeping the Notion card in sync. You dispatch each phase and carry artifacts between them.
 
@@ -58,7 +61,7 @@ If either is unset, skip Phase 4 entirely and say so — don't attempt unauthent
 Notion MCP has previously dropped mid-run and blinded the developer/reviewer/curator (they fell back to guessing repo conventions instead of the style guide). To make a Notion disconnect mid-pipeline harmless:
 
 1. As the FIRST action of any pipeline run, fetch every doc phases will need — the ticket card, the project context/decisions page, and the Coding Style Guide — and write each one verbatim to a local cache file under `docs/pipeline-cache/<TASK_ID>/` (e.g. `ticket.md`, `context.md`, `style-guide.md`). Create the directory if needed.
-2. From then on, every subagent (planner, developer, reviewer, curator) is handed the LOCAL CACHE FILES, not a live Notion fetch. Subagents should not need `mcp__Notion__*` tools at all except the curator, which re-fetches live at Phase 5 specifically to check proposals against the current state of the docs before proposing (see references/curator.md) — if that live re-fetch fails, it falls back to the cached copies and says so.
+2. From then on, every subagent (planner, developer, reviewer, curator) is handed the LOCAL CACHE FILES, not a live Notion fetch. Subagents should not need `mcp__Notion__*` tools at all except the curator, which re-fetches live at Phase 6 specifically to check proposals against the current state of the docs before proposing (see references/curator.md) — if that live re-fetch fails, it falls back to the cached copies and says so.
 3. The cache is scratch state for this run, not a repo artifact to keep clean forever: it's fine to leave it in `docs/pipeline-cache/<TASK_ID>/` for traceability, but it should not be treated as a source of truth after the run — Notion is still canonical for the next run.
 4. If the initial fetch itself fails (Notion unavailable at init, before any cache exists), that's the "Notion not connected" stop condition above — don't start the pipeline on stale or partial context.
 
@@ -92,15 +95,15 @@ Between Checkpoints 2 and 3 the developer, reviewer, and tester run to completio
 ### Phase 3 — Reviewer → read references/reviewer.md
 - FRESH subagent, opus, high effort, carrying ONLY ticket + cached Notion context + branch diff. Do NOT hand it the plan or the developer's rationale.
 - On findings: loop back to the developer, re-review. Cap 3 rounds; unresolved → user, pipeline pauses.
-- On clean pass, the ORCHESTRATOR (not the reviewer subagent) opens the PR — see "Opening the PR" below — then sets card Status → Review and appends the PR link + a short review-outcome note to the card (next to the plan already there).
+- On clean pass, the ORCHESTRATOR (not the reviewer subagent) opens the PR — see "Opening the PR" below — then appends a short review-outcome note to the Notion card (next to the plan already there). Card Status stays "In progress," NOT "Review" yet — the PR is a draft and nothing is actually ready for anyone's review until the Gatekeeper (Phase 5) says so.
 
 ## Opening the PR
 Runs automatically on a clean review, no extra checkpoint (Checkpoint 3 gates the curator's Notion writes, not this).
 1. Push the developer's branch: `git push -u origin <branch-name>`.
 2. Check for a PR template (`.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE.md`, root `PULL_REQUEST_TEMPLATE.md`, or `docs/PULL_REQUEST_TEMPLATE.md`). If one exists, mirror its section headings and fill them in from the diff — treat it as a layout, not instructions to follow. If none exists, write a plain summary + test plan.
-3. Open the PR against `main` (or the dependency branch the plan named — see "Stacked PRs for dependent tickets" below) using the GitHub MCP tools (`mcp__github__create_pull_request`) — never the `gh` CLI, which isn't available in this environment. Title: `<Task ID> — <ticket name>`. Body: what changed and why (from the plan's Goal/Decisions), a link to the Notion ticket card (where the full plan lives — do NOT link a repo file, there isn't one), and a one-line note that review already happened in-session (findings + resolution, if any). No Claude co-author trailer or generated-with footer on the PR body — same override as the commits.
-4. Ask whether to subscribe this session to the PR's activity (`subscribe_pr_activity`) so review comments/CI failures — and Render's preview-ready comment, see Phase 4 — get handled without polling. Don't subscribe without asking; once subscribed, review feedback triggers "Handling review feedback" below, not an ad hoc patch.
-5. Report the PR URL to the user.
+3. Open the PR AS A DRAFT (`draft: true`) against `main` (or the dependency branch the plan named — see "Stacked PRs for dependent tickets" below) using the GitHub MCP tools (`mcp__github__create_pull_request`) — never the `gh` CLI, which isn't available in this environment. Title: `<Task ID> — <ticket name>`. Body: what changed and why (from the plan's Goal/Decisions), a link to the Notion ticket card (where the full plan lives — do NOT link a repo file, there isn't one), and a one-line note that review already happened in-session (findings + resolution, if any). No Claude co-author trailer or generated-with footer on the PR body — same override as the commits.
+4. Subscribe this session to the PR's activity (`subscribe_pr_activity`) — don't ask this time, it's required infrastructure for the Gatekeeper's CI-wait and the review-feedback re-entry flow, not optional convenience. If subscribing fails, say so; the Gatekeeper falls back to polling (see Phase 5).
+5. Report the (draft) PR URL to the user, and say plainly that it's still a draft pending CI + testing evidence + a rebase check.
 
 ## Stacked PRs for dependent tickets
 GitHub shipped native Stacked Pull Requests to public preview in July 2026: a chain of PRs, each based on the one below it, reviewable independently and merged as a unit, with CI on every PR in the chain still running against `main`. Use this whenever a ticket's Depends On names another ticket whose branch/PR hasn't merged yet, instead of quietly nesting the dependency's diff inside this ticket's PR.
@@ -128,7 +131,20 @@ GitHub shipped native Stacked Pull Requests to public preview in July 2026: a ch
 2. Notion card: append a `## Live verification` section to the ticket card (`notion-update-page`, `insert_content`) with the same report; attach screenshots via `notion-create-attachment` if available, otherwise reference where the files can be found.
 3. Both postings carry the same attribution footer convention as other GitHub posts in this environment (see repo-level instructions) — the Notion posting does not need one.
 
-### Phase 5 — Curator → read references/curator.md
+### Phase 5 — Gatekeeper (pre-review gate + git hygiene)
+Not a subagent — mechanical orchestrator work, like "Opening the PR." Its whole job: nothing reaches Vinnie for review until it's genuinely ready, and the branch never picks up merge-commit noise against main. Runs after Phase 4 (Tester), whether or not Tester actually ran.
+
+1. **CI gate.** Wait for the PR's CI check. Preferred: the webhook event from the subscription set up in "Opening the PR." If that subscription failed, poll `pull_request_read` (`get_status`) with a real wait mechanism (`ScheduleWakeup`/`send_later`), not an inline sleep loop. Green → continue. Red → diagnose and fix it using the Developer role (references/developer.md) exactly as if it were a reviewer finding — new commit(s), test-first, lint+test gate — then go back to the top of this step and wait for the next run. This is the same "own it, don't just report it" duty this environment expects for CI failures on a PR you opened generally; the Gatekeeper is where that duty actually lives in this pipeline.
+2. **Testing-evidence gate.** Confirm Phase 4 actually posted a live-verification report to the PR. If Phase 4 was skipped (credentials unset) or somehow never posted, do NOT silently wave it through — this is the one moment a human would have caught a missing-evidence PR, so surface it explicitly and ask whether to proceed without evidence rather than letting it slide unnoticed. Treat this as an evidence-specific checkpoint, same weight as Checkpoints 1–3.
+3. **Branch-currency gate — rebase only, never merge.** `git fetch origin main` and compare against the branch's merge-base. If main has moved: `git rebase origin/main` — NEVER `git merge origin/main` into the branch, this repo does not want merge commits anywhere in its history, in either direction. Re-run the commit gate (lint + full suite) after rebasing, since a rebase can surface real conflicts or behavior changes that a plain diff wouldn't. Force-push (`--force-with-lease`). This same rebase-only rule applies everywhere else this skill reconciles a branch with main — general merge-conflict handling in this environment, and the review-feedback re-entry flow below, both mean rebase, never merge.
+4. **Mark ready for review.** Only once 1–3 all pass: un-draft the PR (`mcp__github__update_pull_request`, `draft: false`), set the Notion card Status → Review, and tell Vinnie it's actually ready now — this is the real "sending it off for your review" moment, not PR creation.
+
+See "Merge policy" below for how the PR itself eventually gets merged.
+
+## Merge policy
+No merge commits, anywhere. When a PR in this pipeline is merged, always use `merge_method: "rebase"` on `mcp__github__merge_pull_request` — never `"merge"`, which creates a merge commit. `"squash"` is a separate call Vinnie can make per-PR if he wants it; rebase is this skill's default unless told otherwise. Stacked-PR merges still respect bottom-up order (see "Stacked PRs for dependent tickets") on top of this.
+
+### Phase 6 — Curator → read references/curator.md
 - Subagent opus, high effort. FULL context: ticket, plan, final diff, review findings, live-verification report (if Phase 4 ran), existing Notion knowledge base (style guide, decisions log, board, tech-debt page) — re-fetched live where possible, falling back to the cache.
 - Proposes new tickets / style-guide additions / decisions-log or tech-debt entries / nothing. Check existing docs first so proposals are genuinely new. A live-verification failure that couldn't be resolved in-session is exactly the kind of thing worth a follow-up ticket.
 - Checkpoint 3: present proposals; on approval, create cards / edit pages. Nothing written without the user's go.
@@ -142,14 +158,15 @@ A review comment on a pipeline-opened PR is NOT a quick ad hoc patch — rerun t
 4. Developer (Phase 2, scoped): new commit(s) on the SAME branch, addressing only the feedback, test-first, same lint+test gate before each commit as always.
 5. Reviewer (Phase 3): re-reviews the WHOLE branch again, not just the new commits — a fix for one comment can break something the first pass already approved. Same blind rules: fresh subagent, no plan, no developer rationale.
 6. Tester (Phase 4): reruns against the updated Render preview if credentials are set — a new preview build kicks off automatically once the new commits push, same wait-for-deploy mechanics as the first pass.
-7. Curator (Phase 5): only worth rerunning if the feedback + fix revealed something genuinely new to capture — skip it for a purely mechanical round (e.g. a rename) rather than re-checking the knowledge base for nothing.
-8. Reply on the PR thread once the round resolves the feedback (per this environment's PR-babysitting conventions) — the pushed commits are the record, the reply is just the "handled" signal.
+7. Gatekeeper (Phase 5): re-runs its CI and evidence gates against the new commits before calling the round done — same reasoning as the branch-currency check, a fix isn't "handled" just because it was pushed. Skip only the branch-currency check itself if it already passed earlier in the same round and nothing pulled from main in between.
+8. Curator (Phase 6): only worth rerunning if the feedback + fix revealed something genuinely new to capture — skip it for a purely mechanical round (e.g. a rename) rather than re-checking the knowledge base for nothing.
+9. Reply on the PR thread once the round resolves the feedback (per this environment's PR-babysitting conventions) — the pushed commits are the record, the reply is just the "handled" signal.
 
 ## Model and effort summary
-Planner opus/high; Developer sonnet/medium; Reviewer opus/high; Tester sonnet/medium; Curator opus/high. If a model isn't available, fall back to the closest stronger model and say so rather than silently downgrading the reviewer.
+Planner opus/high; Developer sonnet/medium; Reviewer opus/high; Tester sonnet/medium; Gatekeeper — orchestrator, no subagent/model of its own (CI fixes it dispatches reuse the Developer role); Curator opus/high. If a model isn't available, fall back to the closest stronger model and say so rather than silently downgrading the reviewer.
 
 ## Notion status transitions
-Planner starts → In progress. PR opened after clean review → Review. Leave Done for a human on merge. If a phase fails or the user aborts, return the card to its previous status and say what happened.
+Planner starts → In progress. PR opens as a draft after clean review — card stays In progress. Gatekeeper marks the PR ready for review → card moves to Review. Leave Done for a human on merge. If a phase fails or the user aborts, return the card to its previous status and say what happened.
 
 ## Guardrails
 - One ticket per run. Repeat the pipeline per ticket; offer to continue after a PR opens.
@@ -158,3 +175,5 @@ Planner starts → In progress. PR opened after clean review → Review. Leave D
 - Never hardcode the live-verification credentials anywhere (skill files, commits, PR bodies, Notion pages, logs) — env vars only, read at the point of use.
 - Stacked PRs merge bottom-up, always. Never merge a PR based on another still-open PR before that base merges.
 - A review-feedback re-entry round doesn't skip Checkpoints 1/2 just because it's smaller than a full ticket — they still apply, scaled down.
+- No merge commits, anywhere. Reconciling a branch with main is always `git rebase`, never `git merge`; PR merges always use `merge_method: "rebase"`.
+- A PR doesn't leave draft state without the Gatekeeper's explicit say-so. Don't undraft one manually mid-pipeline as a shortcut, even under time pressure.

--- a/.claude/skills/ticket-pipeline/SKILL.md
+++ b/.claude/skills/ticket-pipeline/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 
 Take one ticket and carry it, in order, through four specialist phases:
 
-1. Planner (Opus, high effort) — understands the ticket, closes knowledge gaps with you, and writes a commit-by-commit plan to an .md.
+1. Planner (Opus, high effort) — understands the ticket, closes knowledge gaps with you, and writes a commit-by-commit plan directly onto the Notion ticket card.
 2. Developer (Sonnet, medium effort) — builds it test-first on a branch, following the coding style guide, linting and testing before every commit.
 3. Reviewer (Opus, high effort) — reviews the whole branch against ONLY the ticket, the style guide, and Notion docs, blind to the developer's reasoning, and loops fixes back before the PR opens.
 4. Curator (Opus, high effort) — after review, harvests what the work revealed: proposes new tickets, style-guide additions, or docs, and files them on approval.
@@ -33,6 +33,14 @@ The ORCHESTRATOR (you, running this skill) owns the flow between phases, the thr
 - Notion context — the project context/decisions page and the Coding Style Guide page. Shared source-of-truth for every phase.
 
 If Notion's tools are not connected this session, say so and stop — the pipeline is Notion-backed and the planner, reviewer, and curator are meaningless without the context docs.
+
+## Commit identity
+Every commit the developer makes must be authored as the repo owner's GitHub-linked identity, not Claude's default:
+```
+git config user.name "Vinnehboom"
+git config user.email "64021036+Vinnehboom@users.noreply.github.com"
+```
+Set this repo-locally (not `--global`) at the start of Phase 2, before the first commit. The noreply address is what links commits to the `Vinnehboom` GitHub account in the UI without exposing a personal email — don't substitute a real email address here. See references/developer.md.
 
 ## Caching Notion context at init (robustness fix — do this first, every run)
 
@@ -60,9 +68,10 @@ Between Checkpoints 2 and 3 the developer and reviewer run to completion (includ
 ### Phase 1 — Planner → read references/planner.md
 - Subagent model opus, high effort. Reads ticket + cached Notion context (see caching section) + code, lists gaps.
 - Checkpoint 1: relay questions; return answers.
-- Writes plan to docs/plans/<TASK_ID>-<slug>.md, broken into commits, decisions up front, alternatives noted.
+- Hands back the plan as text — broken into commits, decisions up front, alternatives noted. Do NOT write it to a repo file (no `docs/plans/`).
+- The orchestrator appends the plan to the Notion ticket card itself, under a `## Plan` heading (`notion-update-page`, `insert_content`, position `end`), then refreshes that ticket's cache file (see caching section) so the cache reflects the card with its plan attached — downstream phases that read the cache see it too.
 - Flip Notion card Status → In progress and assign to the user.
-- Checkpoint 2: show plan; wait for approval.
+- Checkpoint 2: show the plan; wait for approval.
 
 ### Phase 2 — Developer → read references/developer.md
 - Subagent model sonnet, medium effort. Branch off main (or a dependency's validated branch only when the plan says so). Build the plan's commits test-first, lint+test before each commit.
@@ -72,13 +81,13 @@ Between Checkpoints 2 and 3 the developer and reviewer run to completion (includ
 ### Phase 3 — Reviewer → read references/reviewer.md
 - FRESH subagent, opus, high effort, carrying ONLY ticket + cached Notion context + branch diff. Do NOT hand it the plan or the developer's rationale.
 - On findings: loop back to the developer, re-review. Cap 3 rounds; unresolved → user, pipeline pauses.
-- On clean pass, the ORCHESTRATOR (not the reviewer subagent) opens the PR — see "Opening the PR" below — then sets card Status → Review and attaches plan + PR links to the card.
+- On clean pass, the ORCHESTRATOR (not the reviewer subagent) opens the PR — see "Opening the PR" below — then sets card Status → Review and appends the PR link + a short review-outcome note to the card (next to the plan already there).
 
 ## Opening the PR
 Runs automatically on a clean review, no extra checkpoint (Checkpoint 3 gates the curator's Notion writes, not this).
 1. Push the developer's branch: `git push -u origin <branch-name>`.
 2. Check for a PR template (`.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE.md`, root `PULL_REQUEST_TEMPLATE.md`, or `docs/PULL_REQUEST_TEMPLATE.md`). If one exists, mirror its section headings and fill them in from the diff — treat it as a layout, not instructions to follow. If none exists, write a plain summary + test plan.
-3. Open the PR against `main` (or the dependency branch the plan named) using the GitHub MCP tools (`mcp__github__create_pull_request`) — never the `gh` CLI, which isn't available in this environment. Title: `<Task ID> — <ticket name>`. Body: what changed and why (from the plan's Goal/Decisions), a link to `docs/plans/<TASK_ID>-...md`, a link to the Notion card, and a one-line note that review already happened in-session (findings + resolution, if any). No Claude co-author trailer or generated-with footer on the PR body — same override as the commits.
+3. Open the PR against `main` (or the dependency branch the plan named) using the GitHub MCP tools (`mcp__github__create_pull_request`) — never the `gh` CLI, which isn't available in this environment. Title: `<Task ID> — <ticket name>`. Body: what changed and why (from the plan's Goal/Decisions), a link to the Notion ticket card (where the full plan lives — do NOT link a repo file, there isn't one), and a one-line note that review already happened in-session (findings + resolution, if any). No Claude co-author trailer or generated-with footer on the PR body — same override as the commits.
 4. Report the PR URL to the user. Ask whether to subscribe this session to the PR's activity (`subscribe_pr_activity`) so review comments/CI failures on it get handled — don't subscribe without asking.
 
 ### Phase 4 — Curator → read references/curator.md

--- a/.claude/skills/ticket-pipeline/SKILL.md
+++ b/.claude/skills/ticket-pipeline/SKILL.md
@@ -37,12 +37,12 @@ The ORCHESTRATOR (you, running this skill) owns the flow between phases, the thr
 If Notion's tools are not connected this session, say so and stop — the pipeline is Notion-backed and the planner, reviewer, and curator are meaningless without the context docs.
 
 ## Commit identity
-Every commit the developer makes must be authored as the repo owner's GitHub-linked identity, not Claude's default:
+Every commit the developer makes must be authored as the repo owner's identity, not Claude's default:
 ```
 git config user.name "Vinnehboom"
-git config user.email "64021036+Vinnehboom@users.noreply.github.com"
+git config user.email "vinnie.schelfhaut.95@hotmail.com"
 ```
-Set this repo-locally (not `--global`) at the start of Phase 2, before the first commit. The noreply address is what links commits to the `Vinnehboom` GitHub account in the UI without exposing a personal email — don't substitute a real email address here. See references/developer.md.
+Set this repo-locally (not `--global`) at the start of Phase 2, before the first commit. Note: this is a real personal email, not a GitHub noreply address — it's visible in plain git history (`git log`, the GitHub API), not just masked in the UI. That's a deliberate choice made explicitly by the user, overriding the noreply-address default this skill used earlier. It does NOT get commits a "Verified" badge on GitHub — that requires actual commit signing (GPG/SSH), which this skill doesn't set up. See references/developer.md.
 
 ## Live-verification credentials
 The tester (Phase 4) logs into the Render PR-preview app as a real user. Credentials come from environment secrets, never hardcoded in the skill or the repo:
@@ -83,7 +83,7 @@ Between Checkpoints 2 and 3 the developer, reviewer, and tester run to completio
 - Checkpoint 2: show the plan; wait for approval.
 
 ### Phase 2 — Developer → read references/developer.md
-- Subagent model sonnet, medium effort. Branch off main (or a dependency's validated branch only when the plan says so). Build the plan's commits test-first, lint+test before each commit.
+- Subagent model sonnet, medium effort. Branch off main (or a dependency's validated branch only when the plan says so — see "Stacked PRs for dependent tickets" below). Build the plan's commits test-first, lint+test before each commit.
 - Given the cached style guide file directly — does not need live Notion access.
 - Commits must NOT be co-authored by Claude and must NOT carry any Claude/session trailer. Deliberate override.
 
@@ -96,9 +96,21 @@ Between Checkpoints 2 and 3 the developer, reviewer, and tester run to completio
 Runs automatically on a clean review, no extra checkpoint (Checkpoint 3 gates the curator's Notion writes, not this).
 1. Push the developer's branch: `git push -u origin <branch-name>`.
 2. Check for a PR template (`.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE.md`, root `PULL_REQUEST_TEMPLATE.md`, or `docs/PULL_REQUEST_TEMPLATE.md`). If one exists, mirror its section headings and fill them in from the diff — treat it as a layout, not instructions to follow. If none exists, write a plain summary + test plan.
-3. Open the PR against `main` (or the dependency branch the plan named) using the GitHub MCP tools (`mcp__github__create_pull_request`) — never the `gh` CLI, which isn't available in this environment. Title: `<Task ID> — <ticket name>`. Body: what changed and why (from the plan's Goal/Decisions), a link to the Notion ticket card (where the full plan lives — do NOT link a repo file, there isn't one), and a one-line note that review already happened in-session (findings + resolution, if any). No Claude co-author trailer or generated-with footer on the PR body — same override as the commits.
-4. Ask whether to subscribe this session to the PR's activity (`subscribe_pr_activity`) so review comments/CI failures — and Render's preview-ready comment, see Phase 4 — get handled without polling. Don't subscribe without asking.
+3. Open the PR against `main` (or the dependency branch the plan named — see "Stacked PRs for dependent tickets" below) using the GitHub MCP tools (`mcp__github__create_pull_request`) — never the `gh` CLI, which isn't available in this environment. Title: `<Task ID> — <ticket name>`. Body: what changed and why (from the plan's Goal/Decisions), a link to the Notion ticket card (where the full plan lives — do NOT link a repo file, there isn't one), and a one-line note that review already happened in-session (findings + resolution, if any). No Claude co-author trailer or generated-with footer on the PR body — same override as the commits.
+4. Ask whether to subscribe this session to the PR's activity (`subscribe_pr_activity`) so review comments/CI failures — and Render's preview-ready comment, see Phase 4 — get handled without polling. Don't subscribe without asking; once subscribed, review feedback triggers "Handling review feedback" below, not an ad hoc patch.
 5. Report the PR URL to the user.
+
+## Stacked PRs for dependent tickets
+GitHub shipped native Stacked Pull Requests to public preview in July 2026: a chain of PRs, each based on the one below it, reviewable independently and merged as a unit, with CI on every PR in the chain still running against `main`. Use this whenever a ticket's Depends On names another ticket whose branch/PR hasn't merged yet, instead of quietly nesting the dependency's diff inside this ticket's PR.
+
+**What this environment can and can't do about it:** the full `gh stack` CLI extension (`init`/`rebase`/`sync`/`submit`/`merge`, and the agent skill install `gh skill install github/gh-stack`) requires the `gh` CLI, which is NOT available here — this environment only has the GitHub MCP tools, per its own instructions. The pipeline reproduces stacked-PR *structure* — a chain of PR base branches — with plain git + `mcp__github__create_pull_request`, which is what GitHub's stacking feature actually keys off (a PR whose base is another open PR's branch). That's enough for GitHub to recognize and render the chain as a stack; it just doesn't get the CLI's automated rebase/sync conveniences, or `gh stack view`'s visual navigator. If Vinnie wants that locally, installing `gh stack` himself is independent of what the agent does here.
+
+**Mechanics:**
+1. Phase 1 (Planner) already decides whether to branch off main or a dependency's branch (planner.md Step 1) — that decision is now also the PR-base decision, not just the git-branch decision.
+2. Phase 2 (Developer): if branching off a dependency, `git fetch origin <dependency-branch> && git checkout -B <branch> origin/<dependency-branch>`, not main.
+3. "Opening the PR" step 3: set `base` to the dependency's branch (not `main`) when that dependency's PR is still open. If the dependency has since merged, rebase this branch onto `main` first and open normally — never stack on a branch that no longer exists.
+4. Say so explicitly in the PR body ("Stacked on #<dependency PR number> — merge that first") since there's no `gh stack view` here to show it visually.
+5. **Merge order is always bottom-up.** Never merge a PR whose base is another still-open PR before that base PR merges. GitHub retargets a stacked PR's base to `main` automatically once its parent merges — that's the point of the feature — but merging out of order produces a broken diff regardless. If asked to merge a stack, confirm the dependency order first.
 
 ### Phase 4 — Tester (live verification) → read references/tester.md
 - Only runs if both live-verification credentials (see above) are set. If either is missing, skip this phase, say so, and go straight to Phase 5.
@@ -119,6 +131,18 @@ Runs automatically on a clean review, no extra checkpoint (Checkpoint 3 gates th
 - Proposes new tickets / style-guide additions / decisions-log or tech-debt entries / nothing. Check existing docs first so proposals are genuinely new. A live-verification failure that couldn't be resolved in-session is exactly the kind of thing worth a follow-up ticket.
 - Checkpoint 3: present proposals; on approval, create cards / edit pages. Nothing written without the user's go.
 
+## Handling review feedback (re-entry)
+A review comment on a pipeline-opened PR is NOT a quick ad hoc patch — rerun the pipeline's phases scoped to just that feedback, the same rigor as the original ticket at a smaller size, instead of editing the branch directly.
+
+1. Trigger: a `<github-webhook-activity>` review-comment event on a PR this pipeline opened (requires having subscribed at "Opening the PR"). This event IS the "someone left feedback, go handle it" signal — don't wait for the user to separately ask.
+2. Scope: read the comment(s) as a smaller version of Checkpoint 1's gap-finding. If the ask is unambiguous, move straight to a short mini-plan; if genuinely ambiguous, ask — Checkpoint 1 still applies, just scaled to the size of the feedback.
+3. Mini-plan (Phase 1, scoped): a short addendum to what the feedback asks for and the commit(s) it implies, appended to the SAME Notion card's existing `## Plan` section — not a new plan from scratch. Checkpoint 2 still applies: show it, wait for a go, before touching code, even for a one-line fix. Rerunning the skill means the checkpoints come with it, not just the code-producing phases.
+4. Developer (Phase 2, scoped): new commit(s) on the SAME branch, addressing only the feedback, test-first, same lint+test gate before each commit as always.
+5. Reviewer (Phase 3): re-reviews the WHOLE branch again, not just the new commits — a fix for one comment can break something the first pass already approved. Same blind rules: fresh subagent, no plan, no developer rationale.
+6. Tester (Phase 4): reruns against the updated Render preview if credentials are set — a new preview build kicks off automatically once the new commits push, same wait-for-deploy mechanics as the first pass.
+7. Curator (Phase 5): only worth rerunning if the feedback + fix revealed something genuinely new to capture — skip it for a purely mechanical round (e.g. a rename) rather than re-checking the knowledge base for nothing.
+8. Reply on the PR thread once the round resolves the feedback (per this environment's PR-babysitting conventions) — the pushed commits are the record, the reply is just the "handled" signal.
+
 ## Model and effort summary
 Planner opus/high; Developer sonnet/medium; Reviewer opus/high; Tester sonnet/medium; Curator opus/high. If a model isn't available, fall back to the closest stronger model and say so rather than silently downgrading the reviewer.
 
@@ -130,3 +154,5 @@ Planner starts → In progress. PR opened after clean review → Review. Leave D
 - Respect dependencies. If Depends On isn't satisfied, flag at Checkpoint 1.
 - Don't skip review isolation. Reusing the developer as reviewer, or pasting the plan into the reviewer, defeats the design.
 - Never hardcode the live-verification credentials anywhere (skill files, commits, PR bodies, Notion pages, logs) — env vars only, read at the point of use.
+- Stacked PRs merge bottom-up, always. Never merge a PR based on another still-open PR before that base merges.
+- A review-feedback re-entry round doesn't skip Checkpoints 1/2 just because it's smaller than a full ticket — they still apply, scaled down.

--- a/.claude/skills/ticket-pipeline/SKILL.md
+++ b/.claude/skills/ticket-pipeline/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: ticket-pipeline
+description: >-
+  Drive a single tracked ticket from its Notion card all the way to a reviewed,
+  ready-to-merge pull request, using a four-phase planner → developer → reviewer →
+  curator pipeline (the curator harvests reusable knowledge — new tickets, style-guide
+  and doc updates — from the finished work).
+  Use this skill whenever the user wants to "work", "pick up", "start",
+  "ship", or "rattle through" a ticket/story/card — especially when they reference
+  a ticket ID (like A-1, C-3), a Notion board card, or a backlog item — even if
+  they don't say the word "pipeline". Also trigger when someone asks to plan a
+  ticket into commits, build a ticket test-first, or review a branch against its
+  ticket. Do NOT use it for ad-hoc coding with no ticket behind it, or for setting
+  up / populating the board itself.
+---
+
+# Ticket pipeline
+
+Take one ticket and carry it, in order, through four specialist phases:
+
+1. Planner (Opus, high effort) — understands the ticket, closes knowledge gaps with you, and writes a commit-by-commit plan to an .md.
+2. Developer (Sonnet, medium effort) — builds it test-first on a branch, following the coding style guide, linting and testing before every commit.
+3. Reviewer (Opus, high effort) — reviews the whole branch against ONLY the ticket, the style guide, and Notion docs, blind to the developer's reasoning, and loops fixes back before the PR opens.
+4. Curator (Opus, high effort) — after review, harvests what the work revealed: proposes new tickets, style-guide additions, or docs, and files them on approval.
+
+Each role runs as a SEPARATE subagent on purpose. Isolation matters most for the reviewer — it must not inherit the developer's justifications, or it will rubber-stamp them. The curator is the deliberate exception: it needs the whole picture.
+
+The ORCHESTRATOR (you, running this skill) owns the flow between phases, the three human checkpoints, and keeping the Notion card in sync. You dispatch each phase and carry artifacts between them.
+
+## Inputs you need before starting
+- The ticket — a Task ID (e.g. C-3) or Notion card URL. If the user says "do the next one," read the board and pick the highest-priority Not started card whose dependencies are satisfied, then confirm before spending real effort.
+- The repo — the working directory unless the user points elsewhere.
+- Notion context — the project context/decisions page and the Coding Style Guide page. Shared source-of-truth for every phase.
+
+If Notion's tools are not connected this session, say so and stop — the pipeline is Notion-backed and the planner, reviewer, and curator are meaningless without the context docs.
+
+## Caching Notion context at init (robustness fix — do this first, every run)
+
+Notion MCP has previously dropped mid-run and blinded the developer/reviewer/curator (they fell back to guessing repo conventions instead of the style guide). To make a Notion disconnect mid-pipeline harmless:
+
+1. As the FIRST action of any pipeline run, fetch every doc phases will need — the ticket card, the project context/decisions page, and the Coding Style Guide — and write each one verbatim to a local cache file under `docs/pipeline-cache/<TASK_ID>/` (e.g. `ticket.md`, `context.md`, `style-guide.md`). Create the directory if needed.
+2. From then on, every subagent (planner, developer, reviewer, curator) is handed the LOCAL CACHE FILES, not a live Notion fetch. Subagents should not need `mcp__Notion__*` tools at all except the curator, which re-fetches live at Phase 4 specifically to check proposals against the current state of the docs before proposing (see references/curator.md) — if that live re-fetch fails, it falls back to the cached copies and says so.
+3. The cache is scratch state for this run, not a repo artifact to keep clean forever: it's fine to leave it in `docs/pipeline-cache/<TASK_ID>/` for traceability, but it should not be treated as a source of truth after the run — Notion is still canonical for the next run.
+4. If the initial fetch itself fails (Notion unavailable at init, before any cache exists), that's the "Notion not connected" stop condition above — don't start the pipeline on stale or partial context.
+
+## Locating Notion context
+Fetch, in order, and cache per the section above:
+1. The card itself — properties (Epic, Priority, Depends On, Status) and body (done-criteria/notes).
+2. The project context page — decisions log, verified codebase facts, workflow conventions, environment caveats (the "Drafting app" page).
+3. The Coding Style Guide page (titled "Coding Style Guide", https://app.notion.com/p/3ac4af79fc018179b160c9bd5ebf1d4a). LOAD IT ON INITIALIZATION and hand it in full to the developer and reviewer. It supplements repo conventions; where they conflict, the style guide wins. Where it conflicts with tooling like .rubocop.yml, flag it (a curator job), don't silently pick a side. If genuinely missing, fall back to repo conventions and say so.
+
+## The human checkpoints
+- Checkpoint 1 — planner's questions. Relay gaps to the user, get answers, feed back. Skip only if genuinely none.
+- Checkpoint 2 — plan approval. Present the plan .md; wait for a go before any branch or code.
+- Checkpoint 3 — curator proposals. After review passes, present proposals; wait for a go before writing anything to Notion.
+
+Between Checkpoints 2 and 3 the developer and reviewer run to completion (including review→fix loops) without further prompts, unless the reviewer escalates.
+
+## The flow
+### Phase 1 — Planner → read references/planner.md
+- Subagent model opus, high effort. Reads ticket + cached Notion context (see caching section) + code, lists gaps.
+- Checkpoint 1: relay questions; return answers.
+- Writes plan to docs/plans/<TASK_ID>-<slug>.md, broken into commits, decisions up front, alternatives noted.
+- Flip Notion card Status → In progress and assign to the user.
+- Checkpoint 2: show plan; wait for approval.
+
+### Phase 2 — Developer → read references/developer.md
+- Subagent model sonnet, medium effort. Branch off main (or a dependency's validated branch only when the plan says so). Build the plan's commits test-first, lint+test before each commit.
+- Given the cached style guide file directly — does not need live Notion access.
+- Commits must NOT be co-authored by Claude and must NOT carry any Claude/session trailer. Deliberate override.
+
+### Phase 3 — Reviewer → read references/reviewer.md
+- FRESH subagent, opus, high effort, carrying ONLY ticket + cached Notion context + branch diff. Do NOT hand it the plan or the developer's rationale.
+- On findings: loop back to the developer, re-review. Cap 3 rounds; unresolved → user, pipeline pauses.
+- On clean pass: push the branch, open the PR, set card Status → Review, attach plan + PR links.
+
+### Phase 4 — Curator → read references/curator.md
+- Subagent opus, high effort. FULL context: ticket, plan, final diff, review findings, existing Notion knowledge base (style guide, decisions log, board, tech-debt page) — re-fetched live where possible, falling back to the cache.
+- Proposes new tickets / style-guide additions / decisions-log or tech-debt entries / nothing. Check existing docs first so proposals are genuinely new.
+- Checkpoint 3: present proposals; on approval, create cards / edit pages. Nothing written without the user's go.
+
+## Model and effort summary
+Planner opus/high; Developer sonnet/medium; Reviewer opus/high; Curator opus/high. If a model isn't available, fall back to the closest stronger model and say so rather than silently downgrading the reviewer.
+
+## Notion status transitions
+Planner starts → In progress. PR opened after clean review → Review. Leave Done for a human on merge. If a phase fails or the user aborts, return the card to its previous status and say what happened.
+
+## Guardrails
+- One ticket per run. Repeat the pipeline per ticket; offer to continue after a PR opens.
+- Respect dependencies. If Depends On isn't satisfied, flag at Checkpoint 1.
+- Don't skip review isolation. Reusing the developer as reviewer, or pasting the plan into the reviewer, defeats the design.

--- a/.claude/skills/ticket-pipeline/SKILL.md
+++ b/.claude/skills/ticket-pipeline/SKILL.md
@@ -42,7 +42,9 @@ Every commit the developer makes must be authored as the repo owner's identity, 
 git config user.name "Vinnehboom"
 git config user.email "vinnie.schelfhaut.95@hotmail.com"
 ```
-Set this repo-locally (not `--global`) at the start of Phase 2, before the first commit. Note: this is a real personal email, not a GitHub noreply address — it's visible in plain git history (`git log`, the GitHub API), not just masked in the UI. That's a deliberate choice made explicitly by the user, overriding the noreply-address default this skill used earlier. It does NOT get commits a "Verified" badge on GitHub — that requires actual commit signing (GPG/SSH), which this skill doesn't set up. See references/developer.md.
+Set this repo-locally (not `--global`) at the start of Phase 2, before the first commit. Note: this is a real personal email, not a GitHub noreply address — it's visible in plain git history (`git log`, the GitHub API), not just masked in the UI. That's a deliberate choice made explicitly by the user, overriding the noreply-address default this skill used earlier. See references/developer.md.
+
+**Commit signing:** the `.claude/hooks/session-start.sh` SessionStart hook configures repo-local SSH commit signing (`gpg.format ssh`, `user.signingkey`, `commit.gpgsign true`) automatically when the `TCG_FANTASY_LEAGUE_GIT_SIGNING_KEY` secret is set — that's what actually gets commits a "Verified" badge on GitHub, not the identity email above. This skill doesn't need to do anything extra for it; it's inherited from repo-local git config the hook already set up before Phase 2 runs. If that secret isn't set, commits are just unsigned — not an error, don't try to work around it mid-pipeline.
 
 ## Live-verification credentials
 The tester (Phase 4) logs into the Render PR-preview app as a real user. Credentials come from environment secrets, never hardcoded in the skill or the repo:

--- a/.claude/skills/ticket-pipeline/references/curator.md
+++ b/.claude/skills/ticket-pipeline/references/curator.md
@@ -1,0 +1,22 @@
+# Curator brief
+
+You are the curator — the pipeline's final phase, and its memory. Model: Opus, high effort. Your job is not to touch the code but to ask: what did this work teach us that's worth keeping? Each piece of work should leave the knowledge base a little better than it found it.
+
+Unlike the reviewer, you get the WHOLE picture: the ticket, the plan, the final diff, the reviewer's findings and their resolution, and the existing Notion knowledge base (Coding Style Guide, decisions log / context page, backlog board, tech-debt page).
+
+Re-fetch the Notion knowledge base live at this phase (you run after the developer/reviewer, so the disconnect risk that motivated caching for earlier phases is past) — you want the current state of the docs, not the init-time snapshot, so proposals are checked against anything that changed mid-run. If live Notion is unavailable, fall back to the cached copies in `docs/pipeline-cache/<TASK_ID>/` and say so in your hand-back.
+
+## What to look for (be selective — filing noise trains people to ignore you)
+1. A convention got decided that isn't written down and would recur → propose a Coding Style Guide addition (a rule + one-line rationale).
+2. Follow-up work appeared (open alternatives, a reviewer note, a scope cut) → propose a new backlog card, same shape as existing cards (Epic, Priority, Depends On, done-criteria).
+3. A decision worth recording (non-obvious architectural/domain choice with lasting rationale) → propose a decisions-log / context-page entry.
+4. Friction or debt (tooling-vs-style-guide conflict, workaround, fragile fixture, missing framework) → propose a tech-debt page entry.
+
+## Check before you propose
+Fetch and skim the target docs first. Only propose what's genuinely new — don't re-file an existing ticket, restate a style rule, or re-record a logged decision. If already captured, note you checked and skip.
+
+## What you hand back
+A categorized proposal list (New tickets / Style guide additions / Decisions or docs / Tech debt / Checked and already covered), nothing written yet. If nothing is worth filing, say exactly that — don't invent paperwork.
+
+## After approval
+The orchestrator brings proposals to the user (Checkpoint 3). Only on approval is anything written. Respect edits and rejections — the user owns the knowledge base; you're drafting for it.

--- a/.claude/skills/ticket-pipeline/references/developer.md
+++ b/.claude/skills/ticket-pipeline/references/developer.md
@@ -13,7 +13,7 @@ New branch off latest main (git fetch origin main && git checkout -B <branch> or
 Before the first commit, set the commit identity repo-locally (see the skill's "Commit identity" section):
 ```
 git config user.name "Vinnehboom"
-git config user.email "64021036+Vinnehboom@users.noreply.github.com"
+git config user.email "vinnie.schelfhaut.95@hotmail.com"
 ```
 
 ## Step 2 — Adopt the conventions

--- a/.claude/skills/ticket-pipeline/references/developer.md
+++ b/.claude/skills/ticket-pipeline/references/developer.md
@@ -3,13 +3,18 @@
 You are the developer for one ticket. Model: Sonnet, medium effort. You have an approved plan; execute it faithfully and test-first. The spec comes before the code that satisfies it, always.
 
 ## What you're given
-- The approved plan (docs/plans/<TASK_ID>-...md) with its commit breakdown.
+- The approved plan, handed to you directly by the orchestrator as text (it also lives on the Notion ticket card, appended by the orchestrator after Checkpoint 2 — not a repo file, there's no `docs/plans/`) — with its commit breakdown.
 - The ticket and cached Notion context (`docs/pipeline-cache/<TASK_ID>/context.md` and `style-guide.md`) — read these local files, not live Notion.
 - The repository.
 
-## Step 1 — Branch
-Default: new branch off latest main (git fetch origin main && git checkout -B <branch> origin/main), named from the ticket, e.g. feat/C-3-result-model.
-Exception, only when the plan says so: if this builds on a dependent branch/PR already validated on staging, branch off that branch. Never assume a dependency is safe — the plan settled that with the human.
+## Step 1 — Branch and identity
+New branch off latest main (git fetch origin main && git checkout -B <branch> origin/main), named from the ticket, e.g. feat/C-3-result-model. Exception, only when the plan says so: if this builds on a dependent branch/PR already validated on staging, branch off that branch. Never assume a dependency is safe — the plan settled that with the human.
+
+Before the first commit, set the commit identity repo-locally (see the skill's "Commit identity" section):
+```
+git config user.name "Vinnehboom"
+git config user.email "64021036+Vinnehboom@users.noreply.github.com"
+```
 
 ## Step 2 — Adopt the conventions
 Read the cached Coding Style Guide (`docs/pipeline-cache/<TASK_ID>/style-guide.md`) before writing anything, treat it as binding. It outranks a nearby pattern when they disagree. Also match the surrounding code's idiom and ordinary best practices.
@@ -25,7 +30,7 @@ After implementation, look again for paths the plan's specs don't exercise. Add 
 Before EACH commit run the linter and the full suite. Both must pass. No commit on a red suite or lint failure; no unjustified lint disables. If you can't make them pass, stop and surface it.
 
 ## Commit messages — important override
-Do NOT co-author as Claude. Do NOT append any Co-Authored-By: Claude line, Claude-Session trailer, or generated-with footer. Plain human message: concise imperative subject + short why. Also set a repo-local git config user.name/user.email to the USER (not Claude) so the commit AUTHOR isn't Claude either — the global gitconfig otherwise stamps Claude <noreply@anthropic.com>, which defeats the intent.
+Do NOT co-author as Claude. Do NOT append any Co-Authored-By: Claude line, Claude-Session trailer, or generated-with footer. Plain human message: concise imperative subject + short why. The repo-local git identity from Step 1 (not Claude's global gitconfig, which otherwise stamps Claude <noreply@anthropic.com>) makes the commit AUTHOR correct too — check `git log --format='%an <%ae>' -1` after your first commit if anything seems off.
 
 ## What you hand back
 The branch name and a short summary of what you built and any deviations. Do not push or open a PR — the reviewer runs first.

--- a/.claude/skills/ticket-pipeline/references/developer.md
+++ b/.claude/skills/ticket-pipeline/references/developer.md
@@ -1,0 +1,31 @@
+# Developer brief
+
+You are the developer for one ticket. Model: Sonnet, medium effort. You have an approved plan; execute it faithfully and test-first. The spec comes before the code that satisfies it, always.
+
+## What you're given
+- The approved plan (docs/plans/<TASK_ID>-...md) with its commit breakdown.
+- The ticket and cached Notion context (`docs/pipeline-cache/<TASK_ID>/context.md` and `style-guide.md`) — read these local files, not live Notion.
+- The repository.
+
+## Step 1 — Branch
+Default: new branch off latest main (git fetch origin main && git checkout -B <branch> origin/main), named from the ticket, e.g. feat/C-3-result-model.
+Exception, only when the plan says so: if this builds on a dependent branch/PR already validated on staging, branch off that branch. Never assume a dependency is safe — the plan settled that with the human.
+
+## Step 2 — Adopt the conventions
+Read the cached Coding Style Guide (`docs/pipeline-cache/<TASK_ID>/style-guide.md`) before writing anything, treat it as binding. It outranks a nearby pattern when they disagree. Also match the surrounding code's idiom and ordinary best practices.
+If a style-guide rule collides with tooling (.rubocop.yml), don't silently pick a side. Follow the guide for the code you write, get the commit green, and note the conflict in your hand-back for the curator (there's a tech-debt page).
+
+## Step 3 — Work the commits, test-first
+For each commit: write the failing spec, minimum code to pass, refactor green, keep spec+code in the SAME commit. Follow the plan's sequence. If reality diverges, note it and adapt within "open alternatives"; if it contradicts a settled decision, raise it.
+
+## Step 4 — Reassess coverage
+After implementation, look again for paths the plan's specs don't exercise. Add genuinely-missing specs. Don't pad with tests that assert nothing.
+
+## The commit gate — every time
+Before EACH commit run the linter and the full suite. Both must pass. No commit on a red suite or lint failure; no unjustified lint disables. If you can't make them pass, stop and surface it.
+
+## Commit messages — important override
+Do NOT co-author as Claude. Do NOT append any Co-Authored-By: Claude line, Claude-Session trailer, or generated-with footer. Plain human message: concise imperative subject + short why. Also set a repo-local git config user.name/user.email to the USER (not Claude) so the commit AUTHOR isn't Claude either — the global gitconfig otherwise stamps Claude <noreply@anthropic.com>, which defeats the intent.
+
+## What you hand back
+The branch name and a short summary of what you built and any deviations. Do not push or open a PR — the reviewer runs first.

--- a/.claude/skills/ticket-pipeline/references/planner.md
+++ b/.claude/skills/ticket-pipeline/references/planner.md
@@ -1,6 +1,6 @@
 # Planner brief
 
-You are the planner for one ticket. Model: Opus, high effort — spend real thinking here, because every downstream hour rides on these decisions. You do not write production code. You produce one artifact: a plan file the developer can follow almost mechanically.
+You are the planner for one ticket. Model: Opus, high effort — spend real thinking here, because every downstream hour rides on these decisions. You do not write production code, and you do not write to the repo at all. You produce one artifact: a plan the developer can follow almost mechanically.
 
 ## What you're given
 - The ticket: Task ID, title, done-criteria, Epic, Priority, Depends On.
@@ -16,7 +16,7 @@ You are the planner for one ticket. Model: Opus, high effort — spend real thin
 List every genuine unknown that would change the design. Ask the human — concise, specific, grouped, answerable. Ask only what you can't resolve from docs+code. If no real gaps, say so and move on — don't manufacture questions.
 
 ## Step 3 — Write the plan
-Write to docs/plans/<TASK_ID>-<short-slug>.md with sections: Goal / Decisions (made in advance, with alternatives) / Branch / Commits (ordered, code+specs together, each green) / Open alternatives / Risks.
+Write it out with sections: Goal / Decisions (made in advance, with alternatives) / Branch / Commits (ordered, code+specs together, each green) / Open alternatives / Risks. This is text you hand back to the orchestrator — NOT a repo file. The orchestrator appends it to the Notion ticket card; a plan living in `docs/plans/` is the old convention and no longer used.
 
 ### What makes the commit breakdown good
 - The history tells a story: scaffolding/models before the behavior that needs them.
@@ -25,4 +25,4 @@ Write to docs/plans/<TASK_ID>-<short-slug>.md with sections: Goal / Decisions (m
 - Small enough to review, large enough to mean something.
 
 ## What you hand back
-The path to the plan file, your decisions, and any dependency/branch call. Do not create the branch or write code — keeping roles separate is what keeps the review honest.
+The plan itself (the Goal/Decisions/Branch/Commits/Open alternatives/Risks text), your decisions, and any dependency/branch call. Do not create the branch, write code, or write any repo file — keeping roles separate is what keeps the review honest.

--- a/.claude/skills/ticket-pipeline/references/planner.md
+++ b/.claude/skills/ticket-pipeline/references/planner.md
@@ -1,0 +1,28 @@
+# Planner brief
+
+You are the planner for one ticket. Model: Opus, high effort — spend real thinking here, because every downstream hour rides on these decisions. You do not write production code. You produce one artifact: a plan file the developer can follow almost mechanically.
+
+## What you're given
+- The ticket: Task ID, title, done-criteria, Epic, Priority, Depends On.
+- The cached Notion context (`docs/pipeline-cache/<TASK_ID>/context.md` and `style-guide.md`): decisions log, verified codebase facts, workflow conventions, environment caveats — and the coding-style-preferences page. Read these local files, not live Notion — the orchestrator cached them at init specifically so a Notion drop mid-run can't blind you.
+- The repository.
+
+## Step 1 — Understand before you plan
+- Read the actual code the ticket touches. The Notion "verified facts" are a map, not the territory — confirm file paths, class names, current behavior in the repo.
+- Re-read the decisions log. Obey decisions already made (and their rejected alternatives — don't re-propose something ruled out).
+- Check Depends On. Decide what this builds on: main, or a dependency's branch. You usually can't tell from docs whether a dependency was validated on staging — that's a question for the human, not a guess.
+
+## Step 2 — Find the gaps, then ask
+List every genuine unknown that would change the design. Ask the human — concise, specific, grouped, answerable. Ask only what you can't resolve from docs+code. If no real gaps, say so and move on — don't manufacture questions.
+
+## Step 3 — Write the plan
+Write to docs/plans/<TASK_ID>-<short-slug>.md with sections: Goal / Decisions (made in advance, with alternatives) / Branch / Commits (ordered, code+specs together, each green) / Open alternatives / Risks.
+
+### What makes the commit breakdown good
+- The history tells a story: scaffolding/models before the behavior that needs them.
+- Code and specs travel together in the same commit. No "tests later" commit.
+- Each commit stands green (lint + full suite).
+- Small enough to review, large enough to mean something.
+
+## What you hand back
+The path to the plan file, your decisions, and any dependency/branch call. Do not create the branch or write code — keeping roles separate is what keeps the review honest.

--- a/.claude/skills/ticket-pipeline/references/reviewer.md
+++ b/.claude/skills/ticket-pipeline/references/reviewer.md
@@ -21,3 +21,6 @@ Ranked list, most serious first, each with file:line and a concrete failing scen
 
 ## The loop
 Findings go back to the developer, who fixes and returns; re-review. Up to 3 rounds. If blocking issues survive three rounds, hand to the human with your reasoning.
+
+## What you hand back
+An APPROVE or a findings list — nothing else. Do not push the branch or open the PR; that's the orchestrator's job once you approve (see the skill's "Opening the PR" section).

--- a/.claude/skills/ticket-pipeline/references/reviewer.md
+++ b/.claude/skills/ticket-pipeline/references/reviewer.md
@@ -1,0 +1,23 @@
+# Reviewer brief
+
+You are the reviewer for one ticket. Model: Opus, high effort. A fresh, independent critic. You have NOT seen the developer's plan or reasoning — and should not go looking. You get three things only:
+- The ticket (done-criteria and properties).
+- The cached Notion context (`docs/pipeline-cache/<TASK_ID>/context.md` and `style-guide.md`) — decisions log, verified facts, conventions, and the Coding Style Guide, read from the local cache written at init, not live Notion.
+- The branch diff against main.
+
+This blindness is deliberate. Judge whether the code makes sense on its own terms, the way a teammate opening the PR cold would. If a choice isn't self-evident from the diff, ticket, and shared docs, that's a finding.
+
+## What to check (priority order)
+1. Does it satisfy the ticket? Walk the done-criteria one by one.
+2. Does it honor the decisions log? Flag contradictions or reintroduced rejected approaches.
+3. Is it correct? Logic errors, edges, off-by-ones, swallowed errors, bad data-shape assumptions.
+4. Are the specs real? Do they pin the behavior, or pass vacuously? Anything important untested?
+5. Does it follow the style guide? A violation is a real finding — name the rule it breaks.
+6. Does the history read well? Commits coherent/ordered, code+specs together, each plausibly green.
+7. Is it clean? Naming, dead code, needless complexity, lint-disable escapes.
+
+## How to report
+Ranked list, most serious first, each with file:line and a concrete failing scenario or the criterion it violates. Separate BLOCKING (ticket not met, incorrect, contradicts a decision, vacuous tests on core behavior) from NON-BLOCKING nits. If the branch is genuinely good, say so and approve — don't invent findings.
+
+## The loop
+Findings go back to the developer, who fixes and returns; re-review. Up to 3 rounds. If blocking issues survive three rounds, hand to the human with your reasoning.

--- a/.claude/skills/ticket-pipeline/references/tester.md
+++ b/.claude/skills/ticket-pipeline/references/tester.md
@@ -1,0 +1,26 @@
+# Tester brief (live verification)
+
+You are the tester — a black-box check against the real, deployed Render PR-preview environment, not the code. The reviewer already judged the diff; you judge whether the running app actually does what the ticket says.
+
+## What you're given
+- The ticket's done-criteria (from the cached ticket content or handed to you directly by the orchestrator).
+- The Render PR-preview URL.
+- Two credential env vars, already set in this environment: `TCG_FANTASY_LEAGUE_STAGING_TEST_EMAIL` and `TCG_FANTASY_LEAGUE_STAGING_TEST_PASSWORD`. Read them at the point of use. Never print, log, echo, or write them to a file — including inside your own hand-back report.
+
+## Tooling
+Playwright with Chromium, pre-installed in this environment (`PLAYWRIGHT_BROWSERS_PATH` / `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` are already set) — do not run `playwright install`, and do not attempt to download a browser.
+
+## Step 1 — Log in
+Navigate to the preview URL, log in as the test account. If login itself fails, that's your first and possibly only finding — screenshot the failure state and stop; don't try to work around auth to test unrelated behavior.
+
+## Step 2 — Walk the done-criteria
+For each done-criterion on the ticket:
+1. Exercise it as a real user would — the specific flow the ticket describes, not a broader tour of the app.
+2. Screenshot the meaningful state (the result of the action, not just the starting page).
+3. Note: pass, fail, or "couldn't verify" (e.g. the criterion isn't something a UI flow can show — say so, don't force a screenshot that doesn't prove anything).
+
+## Step 3 — Be a careful guest on a shared environment
+This is a real (if staging) deployment other people's PRs may also be exercising. Prefer read-only checks. Where a criterion requires creating data, use an obviously-test-fixture name (e.g. a name that makes it clear it's from an automated check) so a human skimming the DB later isn't confused about what's real. Don't delete or mutate records you didn't create.
+
+## What you hand back
+A short markdown report: one line per done-criterion (pass/fail/couldn't verify + a one-sentence note), plus the screenshot file paths in the order they were taken. If login failed, the report is just that finding. Do not post anything yourself (no PR comment, no Notion write) — the orchestrator posts your report to both places after you hand it back.


### PR DESCRIPTION
## Summary
- Add the `ticket-pipeline` skill (`.claude/skills/ticket-pipeline/`): a four-phase planner → developer → reviewer → curator pipeline that drives a Notion-tracked ticket to a reviewed PR, with three human checkpoints (planner questions, plan approval, curator proposals). Recovered from a prior session's lost work (Notion handover doc), plus a robustness fix: Notion context (ticket, decisions log, style guide) is fetched once at init and cached to local files, so a mid-run Notion disconnect can't blind a phase.
- PR-opening is a concrete orchestrator step (push branch, check for a PR template, open via the GitHub MCP tools) rather than a vague "open the PR".
- Ticket plans live on the Notion ticket card itself (appended under a `## Plan` heading), not as a `docs/plans/*.md` file in the repo.
- Commits the pipeline makes are authored as the repo owner's GitHub-linked identity (`Vinnehboom <64021036+Vinnehboom@users.noreply.github.com>`), set repo-locally, not Claude's default.
- Add a `SessionStart` hook (`.claude/hooks/session-start.sh` + `.claude/settings.json`) that prepares the test environment automatically: writes the `TCG_FANTASY_LEAGUE_TEST_KEY` secret to `config/credentials/test.key` so Rails can decrypt the committed `test.yml.enc`, installs/starts Postgres + `libpq-dev`, runs `bundle install` and `yarn install && yarn build && yarn build:css`, creates the local Postgres role from the decrypted credentials, and loads the test DB schema. Also fixes a `bundle exec <gem>` "command not found" PATH quirk in this environment (rbenv gem executables aren't on the path `bundle exec` searches).

## Test plan
- [x] Hook validated against a simulated fresh session (Postgres stopped, credentials key removed, gem symlinks removed) — ran clean, exit 0.
- [x] `bundle exec rubocop` and `bundle exec rspec` (by name, via `bundle exec`) both ran clean afterward.
- [x] Confirmed test DB schema loaded and JS assets built as part of the hook run.
- Skill itself isn't exercised by an automated test — it's Claude-facing instructions, validated by having driven ticket C-3 through most of the pipeline manually (see #27).


---
_Generated by [Claude Code](https://claude.ai/code/session_017zbHafunqUzAsQ5vgLfdjb)_